### PR TITLE
Add root redirect for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the static assets for the Merrimore boutique hospitalit
 
 ## Getting started
 
-Open `docs/index.html` directly in your browser or use a simple HTTP server such as `npx serve docs` for local development.
+Open `docs/index.html` directly in your browser or use a simple HTTP server such as `npx serve docs` for local development. The repository root also contains a lightweight `index.html` that redirects to the `docs/` folder, which makes the site available even if GitHub Pages is configured to publish from the root of the `main` branch.
 
 ## Deployment
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=docs/" />
+    <title>Merrimore</title>
+    <link rel="canonical" href="docs/" />
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 2rem;
+        background-color: #f8f6f4;
+        color: #2c2a28;
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+      }
+
+      a {
+        color: #6c4f37;
+      }
+    </style>
+    <script>
+      window.location.replace("docs/");
+    </script>
+  </head>
+  <body>
+    <div>
+      <h1>Redirecting to Merrimore</h1>
+      <p>
+        If you are not redirected automatically, <a href="docs/">click here</a>
+        to visit the site.
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a root-level index.html that redirects to the docs site so the page loads even with default GitHub Pages settings
- document the redirect in the README so contributors know why the file exists

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cbd7278ba08332816839b63f1182a8