### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Prepare static files
+        run: |
+          mkdir -p public
+          cp index.html public/
+          cp -R docs public/
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
 # Shopping Cart App
 
-This repository contains the static assets for the Merrimore boutique hospitality landing page. The full site is available from the repository root (`index.html`) so that GitHub Pages works immediately with the **main branch / root** setting, while the same files are also kept inside `docs/` for teams that prefer the **main branch / docs folder** configuration.
+This repository contains the static assets for the Merrimore boutique hospitality landing page. The full site is available from
+the repository root (`index.html`) so that GitHub Pages works immediately with the **main branch / root** setting, while the same
+files are also kept inside `docs/` for teams that prefer the **main branch / docs folder** configuration.
 
 ## Getting started
 
-Open `index.html` directly in your browser or use a simple HTTP server such as `npx serve .` for local development. If you prefer to work from the `docs/` folder, `docs/index.html` contains the same markup and styles.
+Open `index.html` directly in your browser or use a simple HTTP server such as `npx serve .` for local development. If you prefer
+to work from the `docs/` folder, `docs/index.html` contains the same markup and styles.
 
 ## Deployment
 
-1. Go to the repository settings on GitHub.
-2. In **Pages**, choose either `main` + `/ (root)` or `main` + `/docs`.
-3. Save the settings – GitHub Pages will serve the contents of the selected location at `https://<username>.github.io/shopping-cart-app/`.
+The repository ships with an automated GitHub Actions workflow (`.github/workflows/deploy.yml`) that publishes the static files
+to GitHub Pages whenever the `main` branch is updated. No manual build tooling is required.
 
-The assets referenced by the page use relative paths, so they resolve correctly whether the site is served from the repository root or from the `docs/` directory.
+1. Push your changes to `main`.
+2. The workflow bundles `index.html` and the entire `docs/` directory into a `public/` folder artifact and deploys it to the
+   `gh-pages` environment.
+3. The site becomes available at `https://<username>.github.io/<repository>/` as soon as the deployment completes. For a user
+   site, use a repository named `<username>.github.io` and the same workflow will publish to your root domain.
+
+If you prefer to manage GitHub Pages manually, you can still point the Pages settings to either `main` + `/ (root)` or `main` +
+`/docs`. The assets referenced by the page use relative paths, so they resolve correctly whether the site is served from the
+repository root or from the `docs/` directory.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Merrimore</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="docs/styles.css" />
   </head>
   <body id="top">


### PR DESCRIPTION
## Summary
- align the root landing page markup with the docs version so fonts load consistently
- document the automated publishing flow and update usage notes
- add a GitHub Actions workflow that packages the static files and deploys them to GitHub Pages on every push to main

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68cce3ba6ed08332a3974ca1009a2316