### PR TITLE
Support Pages deployments from main and work branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,9 @@ name: Deploy static site
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - work
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Shopping Cart App
 
 This repository contains the static assets for the Merrimore boutique hospitality landing page. The full site is available from
-the repository root (`index.html`) so that GitHub Pages works immediately with the **main branch / root** setting, while the same
-files are also kept inside `docs/` for teams that prefer the **main branch / docs folder** configuration.
+the repository root (`index.html`) so that GitHub Pages works immediately with either the **main branch / root** or **work branch /
+root** setting, while the same files are also kept inside `docs/` for teams that prefer the **main branch / docs folder** or **work
+branch / docs folder** configuration.
 
 ## Getting started
 
@@ -12,14 +13,14 @@ to work from the `docs/` folder, `docs/index.html` contains the same markup and 
 ## Deployment
 
 The repository ships with an automated GitHub Actions workflow (`.github/workflows/deploy.yml`) that publishes the static files
-to GitHub Pages whenever the `main` branch is updated. No manual build tooling is required.
+to GitHub Pages whenever the `main` or `work` branch is updated. No manual build tooling is required.
 
-1. Push your changes to `main`.
+1. Push your changes to `main` or `work`.
 2. The workflow bundles `index.html` and the entire `docs/` directory into a `public/` folder artifact and deploys it to the
    `gh-pages` environment.
 3. The site becomes available at `https://<username>.github.io/<repository>/` as soon as the deployment completes. For a user
    site, use a repository named `<username>.github.io` and the same workflow will publish to your root domain.
 
-If you prefer to manage GitHub Pages manually, you can still point the Pages settings to either `main` + `/ (root)` or `main` +
+If you prefer to manage GitHub Pages manually, you can still point the Pages settings to either `work` + `/ (root)` or `work` +
 `/docs`. The assets referenced by the page use relative paths, so they resolve correctly whether the site is served from the
 repository root or from the `docs/` directory.


### PR DESCRIPTION
## Summary
- run the GitHub Pages workflow when either the `main` or `work` branch receives updates
- document in the README that Pages can deploy from `main` or `work` using either the root or docs folder

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cce70f96bc8332b487d3b92e87f0db