### PR TITLE
Create Traditional Chinese landing page for goat horn chews

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Merrimore Nomad Provisions | Mongolian Pet Nutrition</title>
+    <title>牧野嚼樂山羊角｜天然狗狗咀嚼零食</title>
+    <meta
+      name="description"
+      content="牧野嚼樂山羊角嚴選100%天然放養山羊角，經三重清潔與消毒，為狗狗提供安全、耐咀嚼且有助潔牙的天然零食。"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -15,65 +19,62 @@
   <body id="top">
     <header class="site-header">
       <div class="container">
-        <nav class="nav" aria-label="Primary">
-          <a class="brand" href="#top">Merrimore Nomad</a>
+        <nav class="nav" aria-label="主要導覽">
+          <a class="brand" href="#top">牧野嚼樂</a>
           <ul class="nav__links">
-            <li><a href="#promise">Story</a></li>
-            <li><a href="#shop">Collections</a></li>
-            <li><a href="#nutrition">Sourcing</a></li>
-            <li><a href="#community">Community</a></li>
+            <li><a href="#highlights">產品亮點</a></li>
+            <li><a href="#shop">規格選購</a></li>
+            <li><a href="#guide">使用指南</a></li>
+            <li><a href="#faq">常見問題</a></li>
+            <li><a href="#stories">顧客分享</a></li>
           </ul>
           <div class="nav__cta">
-            <a class="button button--ghost" href="#promise">Meet the makers</a>
-            <a class="button button--primary" href="#subscribe">Join the Nomad club</a>
+            <a class="button button--ghost" href="#source">了解來源</a>
+            <a class="button button--primary" href="mailto:hello@pasturechew.com">聯絡客服</a>
           </div>
         </nav>
 
         <section class="hero">
           <div class="hero__copy">
-            <span class="hero__eyebrow">Mongolian steppe crafted</span>
-            <h1>Sunrise-yellow pouches packed with nomadic nutrition.</h1>
+            <span class="hero__eyebrow">100% 天然放牧</span>
+            <h1>山羊角嚼勁，滿足毛孩的本能與健康。</h1>
             <p>
-              Inspired by our signature goat horn pouch, Merrimore Nomad pairs
-              grass-fed proteins, alpine herbs, and fermented mare's milk from
-              Mongolia into vibrant meals and chews for modern pets.
+              牧野嚼樂山羊角精選蒙古高原與新疆草場放養山羊自然脫落的角，
+              經三重清潔、蒸氣殺菌與低溫風乾，保留膠原與礦物質，讓毛孩安心咀嚼。
             </p>
             <p>
-              Every order arrives in the same resealable, sunrise-yellow bag seen
-              in Mongolian bazaars—designed to keep aromas bold, textures crisp,
-              and stories of the steppe alive in every bowl.
+              純天然的耐咬口感可幫助清潔牙齒與牙齦，同時滿足狗狗天生的咀嚼欲望，
+              降低破壞性啃咬行為，為居家帶來更長久的平靜與陪伴。
             </p>
             <div class="hero__actions">
-              <a class="button button--primary" href="#shop">Shop the collection</a>
-              <a class="button button--ghost" href="#nutrition">See how we source</a>
+              <a class="button button--primary" href="#shop">立即選購</a>
+              <a class="button button--ghost" href="#source">了解處理流程</a>
             </div>
             <div class="hero__stats">
               <div class="stat-card">
                 <strong>100%</strong>
-                <span>of ingredients are harvested and crafted within Mongolia's
-                  nomadic cooperatives.</span>
+                <span>採用放養山羊自然脫落的角，每支皆可追溯牧場來源。</span>
               </div>
               <div class="stat-card">
-                <strong>48 hrs</strong>
-                <span>to gently air-dry and seal each pouch for optimal chew and
-                  aroma.</span>
+                <strong>3 重淨化</strong>
+                <span>浸泡去雜質、專業刷洗與高溫蒸氣，確保衛生安全。</span>
               </div>
               <div class="stat-card">
-                <strong>0 additives</strong>
-                <span>Our steppe-green packaging protects freshness without dyes or preservatives.</span>
+                <strong>0 添加</strong>
+                <span>不含人工香料、防腐劑與漂白劑，保留純淨原味。</span>
               </div>
             </div>
           </div>
           <div class="hero__media" aria-hidden="true">
             <div class="packaging-shadow"></div>
             <figure class="packaging-mockup">
-              <span class="packaging-mockup__logo">Merrimore</span>
-              <span class="packaging-mockup__badge">Nomad Blend</span>
-              <div class="packaging-mockup__product">Goat Horn Chews</div>
+              <span class="packaging-mockup__logo">牧野嚼樂</span>
+              <span class="packaging-mockup__badge">山羊角系列</span>
+              <div class="packaging-mockup__product">天然咀嚼角</div>
               <ul class="packaging-mockup__notes">
-                <li>Air-dried in Ulaanbaatar</li>
-                <li>Naturally shed horns</li>
-                <li>Collagen-rich crunch</li>
+                <li>放養山羊自然脫角</li>
+                <li>全程專業消毒</li>
+                <li>高膠原耐咀嚼</li>
               </ul>
               <div class="packaging-mockup__scene"></div>
               <div class="packaging-mockup__horns">
@@ -87,15 +88,13 @@
     </header>
 
     <main>
-      <section id="promise" class="section section--light">
+      <section id="highlights" class="section section--light">
         <div class="container">
           <div class="section__heading">
-            <h2>Rooted in the Mongolian steppe, shaped for urban pet bowls.</h2>
+            <h2>為挑嘴又愛咬的毛孩打造的天然選擇。</h2>
             <p>
-              From the sunny band of our pouch to the herbaceous greens inside, each
-              detail mirrors the vibrant packaging crafted by Mongolian designers.
-              We celebrate traditional drying techniques while meeting modern
-              nutrition standards for dogs and cats.
+              我們以原色日出黃的環保包裝承載每一支山羊角，讓毛孩打開就聞得到自然草香。
+              從牧場到餐墊的每一步皆遵循食品級流程，讓飼主輕鬆為愛犬選擇更安心的咀嚼零食。
             </p>
           </div>
           <div class="features">
@@ -104,10 +103,10 @@
                 <rect x="4" y="8" width="40" height="28" rx="14" stroke="#7fbf4c" stroke-width="2.5" />
                 <path d="M18 21l6 6 12-12" stroke="#7fbf4c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
               </svg>
-              <h3>Veterinary approved</h3>
+              <h3>純淨無添加</h3>
               <p>
-                Board-certified partners guide our ingredient ratios so the goats,
-                yak, and fish harvested in Mongolia nourish every life stage.
+                無人工香料、色素與化學漂白，僅保留山羊角原始的膠原與微量元素，
+                讓敏感體質的毛孩也能安心享用。
               </p>
             </article>
             <article class="feature-card">
@@ -121,10 +120,10 @@
                 />
                 <path d="M24 8v32" stroke="#7fbf4c" stroke-width="2.5" stroke-linecap="round" />
               </svg>
-              <h3>Air-dried &amp; pouch protected</h3>
+              <h3>潔牙護齦同步</h3>
               <p>
-                Sun-yellow resealable tops hold in aroma after a 48-hour
-                air-drying cycle, mirroring the artisanal process on the packaging.
+                自然硬度可在咀嚼過程中摩擦牙齒，協助去除牙菌斑並按摩牙齦，
+                搭配獸醫建議的刷牙習慣，讓口腔維持清新健康。
               </p>
             </article>
             <article class="feature-card">
@@ -139,18 +138,18 @@
                 <circle cx="16" cy="16" r="4" stroke="#7fbf4c" stroke-width="2.5" />
                 <circle cx="32" cy="16" r="4" stroke="#7fbf4c" stroke-width="2.5" />
               </svg>
-              <h3>Made for sensitive tummies</h3>
+              <h3>釋放咀嚼天性</h3>
               <p>
-                Steppe botanicals—sea buckthorn, buckwheat, and nettle—mirror the
-                green gradient of our pouch while supporting digestion.
+                長時間的嚼勁能滿足狗狗天生的啃咬需求，降低焦躁與破壞家具的行為，
+                也為居家獨處時光提供安心陪伴。
               </p>
             </article>
           </div>
-          <ul class="pill-list" aria-label="Recipe highlights">
-            <li class="pill">Sun-yellow resealable tops</li>
-            <li class="pill">Human-grade Mongolian proteins</li>
-            <li class="pill">Naturally air-dried</li>
-            <li class="pill">AAFCO-aligned recipes</li>
+          <ul class="pill-list" aria-label="產品重點">
+            <li class="pill">單一動物來源蛋白</li>
+            <li class="pill">低脂肪、耐咀嚼</li>
+            <li class="pill">全齡犬適用</li>
+            <li class="pill">通過第三方微生物檢驗</li>
           </ul>
         </div>
       </section>
@@ -158,116 +157,107 @@
       <section id="shop" class="section">
         <div class="container">
           <div class="section__heading">
-            <h2>Nomad collections inspired by the pouch palette.</h2>
+            <h2>選擇最適合毛孩口感的尺寸。</h2>
             <p>
-              Curate a crate of slow-dried stews, crunchy chews, and probiotic
-              toppers—all sealed in our signature sunrise-yellow bags direct from
-              Mongolia.
+              每支山羊角皆保留自然弧度與紋理，出貨前再次手工拋光並檢查銳角，
+              以便不同體型的狗狗都能安全抓握與啃咬。
             </p>
           </div>
           <div class="product-grid" role="list">
             <article class="product-card" role="listitem">
               <img
-                src="https://images.unsplash.com/photo-1617896851807-0ecdbd1229d4?auto=format&fit=crop&w=800&q=80"
-                alt="Bowl of Merrimore Nomad chicken and pumpkin stew"
+                src="https://images.unsplash.com/photo-1601758003122-58c0ae180d9b?auto=format&fit=crop&w=800&q=80"
+                alt="小型犬正在咀嚼迷你山羊角"
               />
-              <h3>Steppe Chicken &amp; Pumpkin Stew</h3>
-              <p>Free-range chicken, Gobi pumpkin, and seabuckthorn berries in a
-                pouch-ready stew.</p>
-              <span class="price">HK$298 / 6 pouch set</span>
-            </article>
-            <article class="product-card" role="listitem">
-              <img
-                src="https://images.unsplash.com/photo-1601758228041-f3b2795255f1?auto=format&fit=crop&w=800&q=80"
-                alt="Salmon and yak topper being scooped"
-              />
-              <h3>Yak &amp; Salmon Nomad Topper</h3>
-              <p>Wild salmon, grass-fed yak crumble, and toasted buckwheat from
-                Lake Khövsgöl.</p>
-              <span class="price">HK$188 / 280 g pouch</span>
+              <h3>迷你角｜小型犬專用</h3>
+              <p>適合體重 5 公斤以下犬種，表面拋光更容易啃咬，初次嘗試亦推薦。</p>
+              <span class="price">NT$320 / 支</span>
             </article>
             <article class="product-card" role="listitem">
               <img
                 src="https://images.unsplash.com/photo-1558944351-cd118865250c?auto=format&fit=crop&w=800&q=80"
-                alt="Freeze-dried treats on a Merrimore Nomad platter"
+                alt="中型犬與山羊角零食擺設"
               />
-              <h3>Nomad Goat Horn Trio</h3>
-              <p>Naturally shed goat horns, brushed with mare's milk glaze and
-                sealed in our hero pouch.</p>
-              <span class="price">HK$85 / 3-piece set</span>
+              <h3>經典角｜中型犬首選</h3>
+              <p>保留完整膠原層與天然骨髓香氣，適合體重 6–18 公斤的活力毛孩。</p>
+              <span class="price">NT$360 / 支</span>
             </article>
             <article class="product-card" role="listitem">
               <img
-                src="https://images.unsplash.com/photo-1589923188900-85dae523342b?auto=format&fit=crop&w=800&q=80"
-                alt="Green probiotic powder inspired by Mongolian herbs"
+                src="https://images.unsplash.com/photo-1610465299991-3c0c064b2d30?auto=format&fit=crop&w=800&q=80"
+                alt="大型犬叼著完整山羊角"
               />
-              <h3>Steppe Digestive Elixir</h3>
-              <p>Fermented mare's milk powder, nettle, and camelina oil to soothe
-                sensitive tummies.</p>
-              <span class="price">HK$248 / 60 servings</span>
+              <h3>勇士角｜大型犬耐咬</h3>
+              <p>厚實密度帶來更長時間的咀嚼樂趣，適合 20 公斤以上犬種。</p>
+              <span class="price">NT$420 / 支</span>
+            </article>
+            <article class="product-card" role="listitem">
+              <img
+                src="https://images.unsplash.com/photo-1619983081593-ec39c2100951?auto=format&fit=crop&w=800&q=80"
+                alt="山羊角禮盒包裝"
+              />
+              <h3>家庭分享盒</h3>
+              <p>含三種尺寸各一支，再加贈可重複密封的收藏袋，適合多犬家庭備用。</p>
+              <span class="price">NT$980 / 組</span>
             </article>
           </div>
         </div>
       </section>
 
-      <section id="nutrition" class="section section--light">
+      <section id="source" class="section section--light">
         <div class="container">
           <div class="split">
             <div>
               <div class="section__heading">
-                <h2>The Merrimore Nomad supply chain.</h2>
+                <h2>嚴選產地與全程透明處理流程。</h2>
                 <p>
-                  We partner with cooperatives across Arkhangai, Dundgovi, and the
-                  Khentii mountains to gather the meats and herbs that fill our
-                  pouches. Each blend is finished in Ulaanbaatar before travelling
-                  globally in insulated crates.
+                  山羊角來自通過人道放牧認證的合作牧場，僅採收自然脫落角體，
+                  並由具食品加工背景的團隊執行分類、清潔與消毒。每一批產品
+                  都留有批次編號，讓你隨時查詢檢驗報告與運輸紀錄。
                 </p>
               </div>
               <ul class="badge-list">
                 <li class="badge-item">
                   <span class="badge-icon" aria-hidden="true">&#10003;</span>
-                  Individually portioned pouches reduce waste, echoing the bag you
-                  see above.
+                  以植物性溫和清潔液浸泡 12 小時，去除泥沙與雜質。
                 </li>
                 <li class="badge-item">
                   <span class="badge-icon" aria-hidden="true">&#10003;</span>
-                  Pause, swap, or donate shipments to Mongolian rescues with one
-                  click.
+                  125°C 蒸氣殺菌 30 分鐘，再以低溫風乾鎖住膠原。
                 </li>
                 <li class="badge-item">
                   <span class="badge-icon" aria-hidden="true">&#10003;</span>
-                  Complimentary consults help tailor the pouch to sensitive
-                  stomachs and picky eaters.
+                  真空包裝後送第三方實驗室檢驗，合格才上架出貨。
                 </li>
               </ul>
             </div>
             <figure class="hero__media">
               <img
                 src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1000&q=80"
-                alt="Mongolian steppe landscape with grazing animals"
+                alt="放牧山羊在高原草地上悠閒覓食"
               />
             </figure>
           </div>
         </div>
       </section>
 
-      <section id="subscribe" class="section">
+      <section id="guide" class="section">
         <div class="container">
           <div class="subscription">
-            <h2>Join the Merrimore Nomad supply.</h2>
+            <h2>安全享受山羊角的小祕訣。</h2>
             <p>
-              Choose a cadence that mirrors the rhythms of Mongolian herders. We
-              dry, pouch, and ship your blends so they arrive steeped in the same
-              sun-warmed hues as the packaging that inspired this collection.
+              初次提供時請於旁陪伴 10–15 分鐘，讓毛孩熟悉口感並避免吞食過大的碎片。
+              當山羊角咀嚼至小於 5 公分時，建議汰換並改以新角取代，以維持咀嚼安全。
             </p>
             <div class="hero__actions">
-              <a class="button button--primary" href="#shop">Build your crate</a>
-              <a class="button button--ghost" href="mailto:nomad@merrimore.com">Chat with nutrition</a>
+              <a class="button button--primary" href="#shop">挑選合適尺寸</a>
+              <a class="button button--ghost" href="mailto:care@pasturechew.com">詢問營養師</a>
             </div>
             <ul class="pill-list">
-              <li class="pill">Express shipping from Ulaanbaatar</li>
-              <li class="pill">Auto-ship savings up to 15%</li>
-              <li class="pill">Picky eater guarantee</li>
+              <li class="pill">建議每週 2–3 次，每次 20 分鐘</li>
+              <li class="pill">搭配足量飲水，補充水分</li>
+              <li class="pill">避免給予 3 個月以下幼犬</li>
+              <li class="pill">收藏於陰涼乾燥處，遠離陽光</li>
             </ul>
           </div>
         </div>
@@ -276,100 +266,91 @@
       <section id="stories" class="section section--light">
         <div class="container">
           <div class="section__heading">
-            <h2>Pet parents worldwide feel the steppe in every bowl.</h2>
+            <h2>毛爸媽的真心好評。</h2>
             <p>
-              From Hong Kong to Berlin, Merrimore families share how the Nomad
-              pouch delivers aroma, vitality, and Mongolian storytelling.
+              牧野嚼樂陪伴不同年齡與體型的毛孩，共同建立健康的咀嚼習慣與口腔保養。
             </p>
           </div>
           <div class="testimonials">
             <article class="testimonial">
               <p>
-                “Within two weeks of Merrimore Nomad, Luna stopped skipping meals
-                and the sunrise-yellow bag keeps her goat horn chews fresh between
-                hikes.”
+                「拉拉第一次接觸山羊角就愛上，耐咬度讓她安靜地待在床上，牙垢也明顯變少。」
               </p>
-              <cite>Rita &amp; Luna the Aussie</cite>
+              <cite>庭安 &amp; 拉拉（4 歲米克斯）</cite>
             </article>
             <article class="testimonial">
               <p>
-                “My senior cat Miso has a sensitive stomach, but the mare's milk
-                elixir keeps her balanced. She literally sprints when she hears the
-                pouch reseal.”
+                「我們家柯基腸胃敏感，這款沒有人工添加物，吃完也不會拉肚子，真的超安心。」
               </p>
-              <cite>Jon &amp; Miso</cite>
+              <cite>Hank &amp; Pudding（6 歲柯基）</cite>
             </article>
             <article class="testimonial">
               <p>
-                “Being able to donate a shipment to a Mongolian rescue when we
-                travel keeps us loyal to the Nomad program.”
+                「家庭分享盒一次滿足三隻狗狗，不用擔心搶同一支，宅配到府很方便。」
               </p>
-              <cite>The Walker Pack</cite>
+              <cite>林家毛孩小隊</cite>
             </article>
           </div>
         </div>
       </section>
 
-      <section id="community" class="section">
+      <section id="faq" class="section">
         <div class="container">
           <div class="section__heading">
-            <h2>Community bowls &amp; resources.</h2>
+            <h2>常見問題與專家建議。</h2>
             <p>
-              Follow herder stories, seasonal pairings, and enrichment ideas that
-              spotlight our Mongolian partners and the pouch they helped design.
+              若有更多疑問，歡迎隨時寫信或在社群私訊我們的營養師團隊，
+              我們將提供最貼近毛孩需求的建議。
             </p>
           </div>
           <div class="community">
             <article class="community-card">
-              <time datetime="2024-03-18">Mar 18, 2024</time>
-              <h3>Spring bowls for allergy-prone pups</h3>
+              <time datetime="2024-03-18">Q1</time>
+              <h3>山羊角適合幾歲以上的狗狗？</h3>
               <p>
-                Learn how we rotate novel proteins and add anti-inflammatory
-                boosters when pollen levels spike.
+                建議 4 個月以上、已長齊乳牙的幼犬或成犬使用。若牙口較弱，
+                可先從迷你角或較薄的款式開始，並縮短咀嚼時間。
               </p>
-              <a class="button button--ghost" href="#subscribe">Read &amp; shop</a>
+              <a class="button button--ghost" href="mailto:care@pasturechew.com">諮詢更多</a>
             </article>
             <article class="community-card">
-              <time datetime="2024-02-02">Feb 2, 2024</time>
-              <h3>DIY lick mats with Merrimore toppers</h3>
+              <time datetime="2024-02-02">Q2</time>
+              <h3>如果狗狗咬出碎屑怎麼辦？</h3>
               <p>
-                Keep curious noses busy with enrichment ideas featuring our
-                omega-packed toppers.
-              </p>
-              <a class="button button--ghost" href="#shop">Get the recipe</a>
+                請立即收回碎屑並更換新角，避免吞食過小的碎塊。咀嚼過程中
+                建議家長在旁觀察，適時提醒毛孩慢慢咬。</p>
+              <a class="button button--ghost" href="#guide">查看使用指南</a>
             </article>
             <article class="community-card">
-              <time datetime="2024-01-12">Jan 12, 2024</time>
-              <h3>Partnering with Mongolian rescues</h3>
+              <time datetime="2024-01-12">Q3</time>
+              <h3>開封後可以保存多久？</h3>
               <p>
-                See how donated crates support adoption events and foster
-                families throughout Ulaanbaatar and the steppe.
-              </p>
-              <a class="button button--ghost" href="mailto:partners@merrimore.com">Volunteer with us</a>
+                建議置於原裝夾鏈袋或密封罐中，放在陰涼處即可保存 12 個月。
+                若環境潮濕，可放入乾燥劑並定期日照通風 1 小時。</p>
+              <a class="button button--ghost" href="#source">了解來源</a>
             </article>
           </div>
         </div>
       </section>
 
-      <section class="section section--light">
+      <section id="visit" class="section section--light">
         <div class="container">
           <div class="split">
             <div>
-              <h2>Visit our neighborhood market.</h2>
+              <h2>歡迎蒞臨牧野嚼樂期間限定店。</h2>
               <p>
-                Visit the Merrimore Nomad market pop-up for live drying demos,
-                custom pouch stamping, and tastings of our Mongolian mare's milk
-                treats.
+                親自感受山羊角的自然香氣，體驗手作打磨示範，並現場諮詢營養師。
+                現場購買可享免費刻字服務，為毛孩打造專屬咀嚼角。
               </p>
               <div class="hero__actions">
-                <a class="button button--primary" href="https://maps.google.com" target="_blank" rel="noopener">Plan your visit</a>
-                <a class="button button--ghost" href="tel:+18885551212">Call (888) 555-1212</a>
+                <a class="button button--primary" href="https://maps.google.com" target="_blank" rel="noopener">規劃路線</a>
+                <a class="button button--ghost" href="tel:+886223456789">客服專線 (02) 2345-6789</a>
               </div>
             </div>
             <figure class="hero__media">
               <img
                 src="https://images.unsplash.com/photo-1620744738794-a4c4edfb883c?auto=format&fit=crop&w=1000&q=80"
-                alt="Merrimore Nomad market display with Mongolian goods"
+                alt="期間限定店展示山羊角與天然咀嚼零食"
               />
             </figure>
           </div>
@@ -380,8 +361,8 @@
     <footer class="footer">
       <div class="container">
         <div class="footer__inner">
-          <p>&copy; <span id="year"></span> Merrimore Nomad Provisions. All rights reserved.</p>
-          <a href="mailto:nomad@merrimore.com">nomad@merrimore.com</a>
+          <p>&copy; <span id="year"></span> 牧野嚼樂 Pasture Chew. 版權所有。</p>
+          <a href="mailto:hello@pasturechew.com">hello@pasturechew.com</a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- replace the previous Merrimore Nomad layout with a Traditional Chinese landing page focused on natural山羊角狗狗咀嚼零食
- localize navigation, hero content, and feature highlights to emphasize天然來源、潔牙功效與行為管理
- add sections covering尺寸選購、處理流程、使用指南、口碑分享與常見問題，強化產品信任感

## Testing
- Not run (static content changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cfdcebd06c8332aa246a9ee73dfa5a