### PR TITLE
Enable lightbox zoom for gallery images

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -290,6 +290,31 @@ img {
   border-radius: var(--radius-small);
 }
 
+.product-gallery__zoom {
+  border: 0;
+  padding: 0;
+  background: none;
+  cursor: zoom-in;
+  border-radius: var(--radius-small);
+  display: block;
+  overflow: hidden;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.product-gallery__zoom:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(127, 191, 76, 0.35);
+}
+
+.product-gallery__zoom:hover img,
+.product-gallery__zoom:focus-visible img {
+  transform: scale(1.02);
+}
+
+.product-gallery__zoom img {
+  transition: transform 220ms ease;
+}
+
 .product-gallery__item figcaption {
   margin: 0;
   color: var(--color-muted);
@@ -695,6 +720,87 @@ img {
   filter: blur(2px);
   z-index: 0;
   pointer-events: none;
+}
+
+body.lightbox-open {
+  overflow: hidden;
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 6vw, 3rem);
+  background: rgba(16, 34, 31, 0.72);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 180ms ease;
+  z-index: 1200;
+}
+
+.lightbox--open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.lightbox__content {
+  position: relative;
+  width: min(90vw, 720px);
+  max-height: min(90vh, 720px);
+  background: rgba(255, 255, 255, 0.98);
+  border-radius: var(--radius-medium);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  box-shadow: 0 28px 60px rgba(14, 32, 27, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.lightbox__image {
+  width: 100%;
+  max-height: calc(80vh - 6rem);
+  object-fit: contain;
+  border-radius: var(--radius-small);
+}
+
+.lightbox__caption {
+  margin: 0;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.lightbox__close {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.85rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 0;
+  background: rgba(31, 76, 70, 0.1);
+  color: var(--color-secondary);
+  font-size: 1.25rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.lightbox__close:hover,
+.lightbox__close:focus-visible {
+  background: rgba(127, 191, 76, 0.25);
+  color: var(--color-primary-dark);
+}
+
+.lightbox__close:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 @media (max-width: 720px) {

--- a/index.html
+++ b/index.html
@@ -98,23 +98,47 @@
           </div>
           <div class="product-gallery__grid" role="list">
             <figure class="product-gallery__item" role="listitem">
-              <img
-                src="docs/images/product-front.png"
-                alt="牧野嚼樂山羊角正面包裝，透明窗口可見山羊角實物。"
-                loading="lazy"
-              />
+              <button
+                type="button"
+                class="product-gallery__zoom"
+                aria-label="放大檢視圖片"
+                aria-haspopup="dialog"
+                aria-controls="image-lightbox"
+              >
+                <img
+                  src="docs/images/product-front.png"
+                  alt="牧野嚼樂山羊角正面包裝，透明窗口可見山羊角實物。"
+                  loading="lazy"
+                />
+              </button>
               <figcaption>正面夾鏈袋設計搭配透明視窗，開封前即可檢視內容物。</figcaption>
             </figure>
             <figure class="product-gallery__item" role="listitem">
-              <img
-                src="docs/images/product-back.png"
-                alt="牧野嚼樂山羊角背面包裝與成分標示。"
-                loading="lazy"
-              />
+              <button
+                type="button"
+                class="product-gallery__zoom"
+                aria-label="放大檢視圖片"
+                aria-haspopup="dialog"
+                aria-controls="image-lightbox"
+              >
+                <img
+                  src="docs/images/product-back.png"
+                  alt="牧野嚼樂山羊角背面包裝與成分標示。"
+                  loading="lazy"
+                />
+              </button>
               <figcaption>背面標示潔淨來源、營養成分與餵食指南，資訊一目瞭然。</figcaption>
             </figure>
             <figure class="product-gallery__item" role="listitem">
-              <img src="docs/images/product-horns.png" alt="牧野嚼樂精選山羊角的實拍特寫。" loading="lazy" />
+              <button
+                type="button"
+                class="product-gallery__zoom"
+                aria-label="放大檢視圖片"
+                aria-haspopup="dialog"
+                aria-controls="image-lightbox"
+              >
+                <img src="docs/images/product-horns.png" alt="牧野嚼樂精選山羊角的實拍特寫。" loading="lazy" />
+              </button>
               <figcaption>低溫風乾保留天然紋理與膠原，厚實耐咬，提供毛孩滿足嚼勁。</figcaption>
             </figure>
           </div>
@@ -391,6 +415,21 @@
       </section>
     </main>
 
+    <div
+      class="lightbox"
+      id="image-lightbox"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+      tabindex="-1"
+    >
+      <div class="lightbox__content" role="document">
+        <button type="button" class="lightbox__close" aria-label="關閉圖片" data-lightbox-close>&times;</button>
+        <img class="lightbox__image" src="" alt="" />
+        <p class="lightbox__caption"></p>
+      </div>
+    </div>
+
     <footer class="footer">
       <div class="container">
         <div class="footer__inner">
@@ -401,10 +440,89 @@
     </footer>
 
     <script>
-      const yearEl = document.getElementById('year');
-      if (yearEl) {
-        yearEl.textContent = new Date().getFullYear();
-      }
+      (() => {
+        const yearEl = document.getElementById('year');
+        if (yearEl) {
+          yearEl.textContent = new Date().getFullYear();
+        }
+
+        const lightbox = document.getElementById('image-lightbox');
+        if (!lightbox) {
+          return;
+        }
+
+        const lightboxImage = lightbox.querySelector('.lightbox__image');
+        const lightboxCaption = lightbox.querySelector('.lightbox__caption');
+        const closeTriggers = lightbox.querySelectorAll('[data-lightbox-close]');
+        let lastFocusedElement = null;
+
+        function openLightbox(trigger) {
+          const img = trigger.querySelector('img');
+          if (!img || !lightboxImage) {
+            return;
+          }
+
+          const figure = trigger.closest('figure');
+          const captionEl = figure ? figure.querySelector('figcaption') : null;
+
+          lightboxImage.src = img.currentSrc || img.src;
+          lightboxImage.alt = img.alt || '';
+
+          if (lightboxCaption) {
+            lightboxCaption.textContent = captionEl ? captionEl.textContent : '';
+          }
+
+          lightbox.classList.add('lightbox--open');
+          lightbox.removeAttribute('aria-hidden');
+          document.body.classList.add('lightbox-open');
+
+          lastFocusedElement = document.activeElement;
+          const closeButton = lightbox.querySelector('.lightbox__close');
+          if (closeButton) {
+            closeButton.focus();
+          }
+        }
+
+        function closeLightbox() {
+          if (lightboxImage) {
+            lightboxImage.src = '';
+            lightboxImage.alt = '';
+          }
+
+          if (lightboxCaption) {
+            lightboxCaption.textContent = '';
+          }
+
+          lightbox.classList.remove('lightbox--open');
+          lightbox.setAttribute('aria-hidden', 'true');
+          document.body.classList.remove('lightbox-open');
+
+          if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+            lastFocusedElement.focus();
+          }
+          lastFocusedElement = null;
+        }
+
+        document.querySelectorAll('.product-gallery__zoom').forEach((button) => {
+          button.addEventListener('click', () => openLightbox(button));
+        });
+
+        closeTriggers.forEach((trigger) => {
+          trigger.addEventListener('click', closeLightbox);
+        });
+
+        lightbox.addEventListener('click', (event) => {
+          if (event.target === lightbox) {
+            closeLightbox();
+          }
+        });
+
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape' && lightbox.classList.contains('lightbox--open')) {
+            closeLightbox();
+          }
+        });
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap product gallery images with accessible zoom buttons that open a lightbox view
- add shared lightbox markup and script to show captions, restore focus, and support escape to close
- style the zoom triggers and modal overlay so enlarged images display cleanly across devices

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0f73e19b48332be5e7973a1a8af33