### PR TITLE
Fix product gallery display layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # Shopping Cart App
 
-This repository contains the static assets for the Merrimore boutique hospitality landing page. The full site is available from
- codex/fix-accessibility-issues-on-site-m08wfu
-the repository root (`index.html`) so that GitHub Pages works immediately with either the **main branch / root** or **work branch /
-root** setting, while the same files are also kept inside `docs/` for teams that prefer the **main branch / docs folder** or **work
-branch / docs folder** configuration.
-=======
-the repository root (`index.html`) so that GitHub Pages works immediately with the **work branch / root** setting, while the same
-files are also kept inside `docs/` for teams that prefer the **work branch / docs folder** configuration.
- main
+This repository contains the static assets for the Merrimore boutique hospitality landing page. The full site is available from the
+repository root (`index.html`) so that GitHub Pages works immediately with either the **main branch / root** or **main branch / docs
+folder** configuration. The same files are also duplicated inside `docs/` for teams that prefer serving from that directory.
 
 ## Getting started
 
@@ -17,21 +11,15 @@ to work from the `docs/` folder, `docs/index.html` contains the same markup and 
 
 ## Deployment
 
-The repository ships with an automated GitHub Actions workflow (`.github/workflows/deploy.yml`) that publishes the static files
- codex/fix-accessibility-issues-on-site-m08wfu
-to GitHub Pages whenever the `main` or `work` branch is updated. No manual build tooling is required.
+The repository ships with an automated GitHub Actions workflow (`.github/workflows/deploy.yml`) that publishes the static files to
+GitHub Pages whenever the `main` branch is updated. No manual build tooling is required.
 
-1. Push your changes to `main` or `work`.
-=======
-to GitHub Pages whenever the `work` branch is updated. No manual build tooling is required.
-
-1. Push your changes to `work`.
- main
+1. Push your changes to `main`.
 2. The workflow bundles `index.html` and the entire `docs/` directory into a `public/` folder artifact and deploys it to the
    `gh-pages` environment.
 3. The site becomes available at `https://<username>.github.io/<repository>/` as soon as the deployment completes. For a user
    site, use a repository named `<username>.github.io` and the same workflow will publish to your root domain.
 
-If you prefer to manage GitHub Pages manually, you can still point the Pages settings to either `work` + `/ (root)` or `work` +
+If you prefer to manage GitHub Pages manually, you can still point the Pages settings to either `main` + `/ (root)` or `main` +
 `/docs`. The assets referenced by the page use relative paths, so they resolve correctly whether the site is served from the
 repository root or from the `docs/` directory.

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -321,43 +321,43 @@ img {
   background: #ffffff;
 }
 
- codex/modify-image-display-for-zoom-feature-ltapmj
-=======
-.product-gallery__zoom {
-  border: 0;
-  padding: 0;
-  background: none;
-  cursor: zoom-in;
-  border-radius: var(--radius-small);
-  display: block;
-  overflow: hidden;
-  transition: transform 160ms ease, box-shadow 160ms ease;
-}
-
-.product-gallery__zoom:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(127, 191, 76, 0.35);
-}
-
- main
 .product-gallery__zoom:hover img,
 .product-gallery__zoom:focus-visible img {
   transform: scale(1.02);
 }
 
- codex/modify-image-display-for-zoom-feature-ltapmj
 .product-gallery__caption {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-muted);
+  max-width: 540px;
+}
 
-.product-gallery__zoom img {
-  transition: transform 220ms ease;
+.product-gallery__grid {
+  width: min(100%, 960px);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.product-gallery__item {
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(31, 76, 70, 0.08);
+  box-shadow: var(--shadow-card);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1rem);
+  text-align: center;
 }
 
 .product-gallery__item figcaption {
- main
   margin: 0;
   color: var(--color-muted);
-  font-size: 1.02rem;
-  max-width: 540px;
+  line-height: 1.6;
 }
 
 .product-gallery__thumbnails {

--- a/index.html
+++ b/index.html
@@ -96,13 +96,8 @@
               從外包裝到實際的山羊角，每一面向都以透明與嚴謹呈現，讓您在下單前就能看見牧野嚼樂的用心。
             </p>
           </div>
- codex/modify-image-display-for-zoom-feature-ltapmj
           <div class="product-gallery__layout">
             <figure class="product-gallery__display">
-
-          <div class="product-gallery__grid" role="list">
-            <figure class="product-gallery__item" role="listitem">
- main
               <button
                 type="button"
                 class="product-gallery__zoom"
@@ -110,50 +105,64 @@
                 aria-haspopup="dialog"
                 aria-controls="image-lightbox"
               >
-                <img
-                  src="docs/images/product-front.png"
-                  alt="牧野嚼樂山羊角正面包裝，透明窗口可見山羊角實物。"
- codex/modify-image-display-for-zoom-feature-ltapmj
-                />
+                <img src="docs/images/product-front.png" alt="牧野嚼樂山羊角正面包裝，透明窗口可見山羊角實物。" />
               </button>
               <figcaption class="product-gallery__caption">
                 正面夾鏈袋設計搭配透明視窗，開封前即可檢視內容物。
               </figcaption>
+            </figure>
 
-                  loading="lazy"
-                />
-              </button>
-              <figcaption>正面夾鏈袋設計搭配透明視窗，開封前即可檢視內容物。</figcaption>
-            </figure>
-            <figure class="product-gallery__item" role="listitem">
-              <button
-                type="button"
-                class="product-gallery__zoom"
-                aria-label="放大檢視圖片"
-                aria-haspopup="dialog"
-                aria-controls="image-lightbox"
-              >
-                <img
-                  src="docs/images/product-back.png"
-                  alt="牧野嚼樂山羊角背面包裝與成分標示。"
-                  loading="lazy"
-                />
-              </button>
-              <figcaption>背面標示潔淨來源、營養成分與餵食指南，資訊一目瞭然。</figcaption>
-            </figure>
-            <figure class="product-gallery__item" role="listitem">
-              <button
-                type="button"
-                class="product-gallery__zoom"
-                aria-label="放大檢視圖片"
-                aria-haspopup="dialog"
-                aria-controls="image-lightbox"
-              >
-                <img src="docs/images/product-horns.png" alt="牧野嚼樂精選山羊角的實拍特寫。" loading="lazy" />
-              </button>
-              <figcaption>低溫風乾保留天然紋理與膠原，厚實耐咬，提供毛孩滿足嚼勁。</figcaption>
- main
-            </figure>
+            <div class="product-gallery__grid" role="list">
+              <figure class="product-gallery__item" role="listitem">
+                <button
+                  type="button"
+                  class="product-gallery__zoom"
+                  aria-label="放大檢視圖片"
+                  aria-haspopup="dialog"
+                  aria-controls="image-lightbox"
+                >
+                  <img
+                    src="docs/images/product-front.png"
+                    alt="牧野嚼樂山羊角正面包裝，透明窗口可見山羊角實物。"
+                    loading="lazy"
+                  />
+                </button>
+                <figcaption>正面夾鏈袋設計搭配透明視窗，開封前即可檢視內容物。</figcaption>
+              </figure>
+              <figure class="product-gallery__item" role="listitem">
+                <button
+                  type="button"
+                  class="product-gallery__zoom"
+                  aria-label="放大檢視圖片"
+                  aria-haspopup="dialog"
+                  aria-controls="image-lightbox"
+                >
+                  <img
+                    src="docs/images/product-back.png"
+                    alt="牧野嚼樂山羊角背面包裝與成分標示。"
+                    loading="lazy"
+                  />
+                </button>
+                <figcaption>背面標示潔淨來源、營養成分與餵食指南，資訊一目瞭然。</figcaption>
+              </figure>
+              <figure class="product-gallery__item" role="listitem">
+                <button
+                  type="button"
+                  class="product-gallery__zoom"
+                  aria-label="放大檢視圖片"
+                  aria-haspopup="dialog"
+                  aria-controls="image-lightbox"
+                >
+                  <img
+                    src="docs/images/product-horns.png"
+                    alt="牧野嚼樂精選山羊角的實拍特寫。"
+                    loading="lazy"
+                  />
+                </button>
+                <figcaption>低溫風乾保留天然紋理與膠原，厚實耐咬，提供毛孩滿足嚼勁。</figcaption>
+              </figure>
+            </div>
+
             <div class="product-gallery__thumbnails" role="listbox" aria-label="瀏覽產品不同視角">
               <button
                 type="button"
@@ -494,7 +503,6 @@
           yearEl.textContent = new Date().getFullYear();
         }
 
- codex/modify-image-display-for-zoom-feature-ltapmj
         const gallery = document.querySelector('.product-gallery');
         if (gallery) {
           const displayImage = gallery.querySelector('.product-gallery__zoom img');
@@ -567,8 +575,6 @@
           }
         }
 
-
- main
         const lightbox = document.getElementById('image-lightbox');
         if (!lightbox) {
           return;


### PR DESCRIPTION
## Summary
- repair the product gallery markup to restore the main display image, figure captions, and accessible thumbnail controls
- refresh the related CSS so the gallery items render as centered cards and the caption styles no longer include conflict debris
- clean up README.md to remove merge artifact text and clarify the deployment instructions

## Testing
- python -m http.server 8000 (manual visual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d0fc3d2a1883329a163ac3c1511b02