### PR TITLE
feat: add hero product gallery layout

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -227,6 +227,114 @@ img {
   justify-content: center;
 }
 
+.hero-gallery {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  width: min(100%, 420px);
+}
+
+.hero-gallery__display {
+  width: 100%;
+  background: linear-gradient(180deg, rgba(245, 249, 241, 0.96) 0%, rgba(255, 255, 255, 0.9) 100%);
+  padding: clamp(1.25rem, 3vw, 1.9rem);
+  border-radius: var(--radius-large);
+  box-shadow: var(--shadow-card);
+  border: 1px solid rgba(31, 76, 70, 0.12);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.9rem, 2vw, 1.25rem);
+}
+
+.hero-gallery__main {
+  border: 0;
+  width: 100%;
+  padding: clamp(0.75rem, 2.5vw, 1.5rem);
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: var(--radius-medium);
+  cursor: zoom-in;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 0 1px rgba(31, 76, 70, 0.08);
+  transition: box-shadow 160ms ease, transform 160ms ease;
+}
+
+.hero-gallery__main:focus-visible {
+  outline: none;
+  box-shadow:
+    inset 0 0 0 1px rgba(31, 76, 70, 0.1),
+    0 0 0 3px rgba(127, 191, 76, 0.35);
+}
+
+.hero-gallery__main:hover {
+  transform: translateY(-2px);
+}
+
+.hero-gallery__image {
+  width: min(100%, 320px);
+  aspect-ratio: 3 / 4;
+  object-fit: contain;
+  border-radius: calc(var(--radius-medium) - 4px);
+  box-shadow: 0 18px 36px rgba(31, 76, 70, 0.18);
+  background: #ffffff;
+}
+
+.hero-gallery__caption {
+  margin: 0;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.98rem;
+  line-height: 1.6;
+}
+
+.hero-gallery__thumbnails {
+  display: flex;
+  gap: clamp(0.6rem, 2vw, 1rem);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.hero-gallery__thumbnail {
+  border: 0;
+  padding: clamp(0.35rem, 1.5vw, 0.6rem);
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: var(--radius-small);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: var(--shadow-card);
+  border: 2px solid transparent;
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+  width: clamp(88px, 12vw, 110px);
+  aspect-ratio: 3 / 4;
+}
+
+.hero-gallery__thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: calc(var(--radius-small) - 2px);
+}
+
+.hero-gallery__thumbnail:hover {
+  transform: translateY(-2px);
+}
+
+.hero-gallery__thumbnail:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(127, 191, 76, 0.35);
+}
+
+.hero-gallery__thumbnail.is-active,
+.hero-gallery__thumbnail[aria-selected='true'] {
+  border-color: rgba(127, 191, 76, 0.85);
+  box-shadow: 0 18px 32px rgba(127, 191, 76, 0.18);
+}
+
 .section {
   padding: clamp(3.5rem, 8vw, 6rem) 0;
 }

--- a/index.html
+++ b/index.html
@@ -65,23 +65,63 @@
               </div>
             </div>
           </div>
-          <div class="hero__media" aria-hidden="true">
-            <div class="packaging-shadow"></div>
-            <figure class="packaging-mockup">
-              <span class="packaging-mockup__logo">牧野嚼樂</span>
-              <span class="packaging-mockup__badge">山羊角系列</span>
-              <div class="packaging-mockup__product">天然咀嚼角</div>
-              <ul class="packaging-mockup__notes">
-                <li>放養山羊自然脫角</li>
-                <li>全程專業消毒</li>
-                <li>高膠原耐咀嚼</li>
-              </ul>
-              <div class="packaging-mockup__scene"></div>
-              <div class="packaging-mockup__horns">
-                <span></span>
-                <span></span>
+          <div class="hero__media">
+            <div class="hero-gallery">
+              <figure class="hero-gallery__display">
+                <button
+                  type="button"
+                  class="hero-gallery__main"
+                  aria-label="放大檢視產品正面"
+                >
+                  <img
+                    class="hero-gallery__image"
+                    src="docs/images/product-front.png"
+                    alt="牧野嚼樂山羊角正面包裝，透明窗口可見山羊角實物。"
+                  />
+                </button>
+                <figcaption class="hero-gallery__caption">
+                  正面夾鏈袋設計搭配透明視窗，開封前即可檢視內容物。
+                </figcaption>
+              </figure>
+              <div class="hero-gallery__thumbnails" role="listbox" aria-label="切換產品視角">
+                <button
+                  type="button"
+                  class="hero-gallery__thumbnail is-active"
+                  role="option"
+                  aria-selected="true"
+                  data-image="docs/images/product-front.png"
+                  data-alt="牧野嚼樂山羊角正面包裝，透明窗口可見山羊角實物。"
+                  data-caption="正面夾鏈袋設計搭配透明視窗，開封前即可檢視內容物。"
+                  data-label="產品正面"
+                >
+                  <img src="docs/images/product-front.png" alt="牧野嚼樂山羊角正面包裝縮圖" loading="lazy" />
+                </button>
+                <button
+                  type="button"
+                  class="hero-gallery__thumbnail"
+                  role="option"
+                  aria-selected="false"
+                  data-image="docs/images/product-back.png"
+                  data-alt="牧野嚼樂山羊角背面包裝與成分標示。"
+                  data-caption="背面標示潔淨來源、營養成分與餵食指南，資訊一目瞭然。"
+                  data-label="產品背面"
+                >
+                  <img src="docs/images/product-back.png" alt="牧野嚼樂山羊角背面包裝縮圖" loading="lazy" />
+                </button>
+                <button
+                  type="button"
+                  class="hero-gallery__thumbnail"
+                  role="option"
+                  aria-selected="false"
+                  data-image="docs/images/product-horns.png"
+                  data-alt="牧野嚼樂精選山羊角的實拍特寫。"
+                  data-caption="低溫風乾保留天然紋理與膠原，厚實耐咬，提供毛孩滿足嚼勁。"
+                  data-label="產品細節"
+                >
+                  <img src="docs/images/product-horns.png" alt="牧野嚼樂山羊角特寫縮圖" loading="lazy" />
+                </button>
               </div>
-            </figure>
+            </div>
           </div>
         </section>
       </div>
@@ -503,6 +543,86 @@
           yearEl.textContent = new Date().getFullYear();
         }
 
+        const heroGallery = document.querySelector('.hero-gallery');
+        if (heroGallery) {
+          const mainButton = heroGallery.querySelector('.hero-gallery__main');
+          const mainImage = heroGallery.querySelector('.hero-gallery__image');
+          const mainCaption = heroGallery.querySelector('.hero-gallery__caption');
+          const thumbnails = Array.from(heroGallery.querySelectorAll('.hero-gallery__thumbnail'));
+
+          function setActiveHeroThumbnail(target) {
+            thumbnails.forEach((thumb) => {
+              const isActive = thumb === target;
+              thumb.classList.toggle('is-active', isActive);
+              thumb.setAttribute('aria-selected', isActive ? 'true' : 'false');
+              thumb.tabIndex = isActive ? 0 : -1;
+            });
+          }
+
+          function updateHeroGallery(thumbnail) {
+            if (!thumbnail || !mainImage) {
+              return;
+            }
+
+            const newSrc = thumbnail.dataset.image;
+            if (newSrc && mainImage.getAttribute('src') !== newSrc) {
+              mainImage.setAttribute('src', newSrc);
+            }
+
+            const newAlt = thumbnail.dataset.alt || '';
+            mainImage.alt = newAlt;
+
+            if (mainCaption) {
+              mainCaption.textContent = thumbnail.dataset.caption || '';
+            }
+
+            if (mainButton) {
+              const labelText = thumbnail.dataset.label || newAlt || '產品圖片';
+              mainButton.setAttribute('aria-label', `放大檢視${labelText}`);
+            }
+
+            setActiveHeroThumbnail(thumbnail);
+          }
+
+          thumbnails.forEach((thumbnail) => {
+            const labelText = thumbnail.dataset.label || thumbnail.dataset.caption || thumbnail.dataset.alt;
+            if (labelText) {
+              thumbnail.setAttribute('aria-label', labelText);
+            }
+
+            thumbnail.addEventListener('click', () => updateHeroGallery(thumbnail));
+
+            thumbnail.addEventListener('keydown', (event) => {
+              if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+                return;
+              }
+
+              event.preventDefault();
+              const currentIndex = thumbnails.indexOf(thumbnail);
+              if (currentIndex === -1) {
+                return;
+              }
+
+              const offset = event.key === 'ArrowLeft' ? -1 : 1;
+              const nextIndex = (currentIndex + offset + thumbnails.length) % thumbnails.length;
+              const nextThumbnail = thumbnails[nextIndex];
+
+              if (nextThumbnail) {
+                nextThumbnail.focus();
+                nextThumbnail.click();
+              }
+            });
+          });
+
+          const activeHeroThumbnail = thumbnails.find(
+            (thumb) => thumb.classList.contains('is-active') || thumb.getAttribute('aria-selected') === 'true',
+          );
+
+          if (activeHeroThumbnail) {
+            updateHeroGallery(activeHeroThumbnail);
+          }
+        }
+
         const gallery = document.querySelector('.product-gallery');
         if (gallery) {
           const displayImage = gallery.querySelector('.product-gallery__zoom img');
@@ -632,7 +752,7 @@
           lastFocusedElement = null;
         }
 
-        document.querySelectorAll('.product-gallery__zoom').forEach((button) => {
+        document.querySelectorAll('.product-gallery__zoom, .hero-gallery__main').forEach((button) => {
           button.addEventListener('click', () => openLightbox(button));
         });
 


### PR DESCRIPTION
## Summary
- replace the hero mockup with a live product gallery featuring a main image and supporting thumbnails
- add styling updates so the hero imagery sits comfortably beside the marketing copy
- extend the gallery script so hero thumbnails update the main image and integrate with the lightbox experience

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1434881d88332a469a6498f1eaeb4