### PR TITLE
Remove gallery borders and adjust thumbnails

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -237,11 +237,9 @@ img {
 
 .hero-gallery__display {
   width: 100%;
-  background: linear-gradient(180deg, rgba(245, 249, 241, 0.96) 0%, rgba(255, 255, 255, 0.9) 100%);
+  background: transparent;
   padding: clamp(1.25rem, 3vw, 1.9rem);
   border-radius: var(--radius-large);
-  box-shadow: var(--shadow-card);
-  border: 1px solid rgba(31, 76, 70, 0.12);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -251,15 +249,14 @@ img {
 .hero-gallery__main {
   border: 0;
   width: 100%;
-  padding: clamp(0.75rem, 2.5vw, 1.5rem);
-  background: rgba(255, 255, 255, 0.94);
+  padding: clamp(0.5rem, 2vw, 1rem);
+  background: transparent;
   border-radius: var(--radius-medium);
   cursor: zoom-in;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: inset 0 0 0 1px rgba(31, 76, 70, 0.08);
-  transition: box-shadow 160ms ease, transform 160ms ease;
+  transition: transform 160ms ease;
 }
 
 .hero-gallery__main:focus-visible {
@@ -278,8 +275,8 @@ img {
   aspect-ratio: 3 / 4;
   object-fit: contain;
   border-radius: calc(var(--radius-medium) - 4px);
-  box-shadow: 0 18px 36px rgba(31, 76, 70, 0.18);
-  background: #ffffff;
+  box-shadow: none;
+  background: transparent;
 }
 
 .hero-gallery__caption {
@@ -299,17 +296,17 @@ img {
 
 .hero-gallery__thumbnail {
   border: 0;
-  padding: clamp(0.35rem, 1.5vw, 0.6rem);
-  background: rgba(255, 255, 255, 0.95);
+  padding: clamp(0.25rem, 1.2vw, 0.45rem);
+  background: transparent;
   border-radius: var(--radius-small);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: var(--shadow-card);
+  box-shadow: none;
   border: 2px solid transparent;
-  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
-  width: clamp(88px, 12vw, 110px);
+  transition: transform 160ms ease, border-color 160ms ease;
+  width: clamp(72px, 9vw, 96px);
   aspect-ratio: 3 / 4;
 }
 
@@ -318,6 +315,7 @@ img {
   height: 100%;
   object-fit: contain;
   border-radius: calc(var(--radius-small) - 2px);
+  background: transparent;
 }
 
 .hero-gallery__thumbnail:hover {
@@ -385,11 +383,9 @@ img {
 
 .product-gallery__display {
   width: min(100%, 680px);
-  background: rgba(255, 255, 255, 0.94);
+  background: transparent;
   padding: clamp(1.75rem, 4vw, 2.5rem);
   border-radius: var(--radius-large);
-  box-shadow: var(--shadow-card);
-  border: 1px solid rgba(31, 76, 70, 0.12);
   display: flex;
   flex-direction: column;
   gap: clamp(1.25rem, 3vw, 1.75rem);
@@ -399,8 +395,8 @@ img {
 
 .product-gallery__zoom {
   border: 0;
-  padding: clamp(1rem, 3vw, 1.75rem);
-  background: linear-gradient(180deg, rgba(245, 249, 241, 0.96) 0%, rgba(255, 255, 255, 0.9) 100%);
+  padding: clamp(0.75rem, 2.5vw, 1.5rem);
+  background: transparent;
   cursor: zoom-in;
   border-radius: var(--radius-medium);
   display: flex;
@@ -408,15 +404,12 @@ img {
   justify-content: center;
   width: 100%;
   overflow: hidden;
-  transition: box-shadow 160ms ease, background 160ms ease;
-  box-shadow: inset 0 0 0 1px rgba(31, 76, 70, 0.08);
+  transition: transform 160ms ease;
 }
 
 .product-gallery__zoom:focus-visible {
   outline: none;
-  box-shadow:
-    inset 0 0 0 1px rgba(31, 76, 70, 0.08),
-    0 0 0 3px rgba(127, 191, 76, 0.35);
+  box-shadow: 0 0 0 3px rgba(127, 191, 76, 0.35);
 }
 
 .product-gallery__zoom img {
@@ -424,9 +417,9 @@ img {
   max-height: clamp(280px, 42vw, 460px);
   object-fit: contain;
   border-radius: var(--radius-small);
-  box-shadow: 0 18px 36px rgba(31, 76, 70, 0.15);
+  box-shadow: none;
   transition: transform 220ms ease;
-  background: #ffffff;
+  background: transparent;
 }
 
 .product-gallery__zoom:hover img,
@@ -478,18 +471,18 @@ img {
 
 .product-gallery__thumbnail {
   border: 0;
-  padding: clamp(0.4rem, 1.5vw, 0.75rem);
-  background: rgba(255, 255, 255, 0.95);
+  padding: clamp(0.3rem, 1.4vw, 0.6rem);
+  background: transparent;
   border-radius: var(--radius-small);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   overflow: hidden;
-  box-shadow: var(--shadow-card);
+  box-shadow: none;
   border: 2px solid transparent;
-  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
-  width: clamp(110px, 18vw, 150px);
+  transition: transform 160ms ease, border-color 160ms ease;
+  width: clamp(96px, 16vw, 132px);
   aspect-ratio: 3 / 4;
 }
 
@@ -498,6 +491,7 @@ img {
   height: 100%;
   object-fit: contain;
   border-radius: calc(var(--radius-small) - 2px);
+  background: transparent;
 }
 
 .product-gallery__thumbnail:hover {


### PR DESCRIPTION
## Summary
- remove borders and white backgrounds from hero and product gallery main images so PNG transparency shows through
- shrink gallery thumbnails and clean up default thumbnail styling for a lighter presentation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d146213240833290534e178cef82cc