### PR TITLE
Expand hero main image to full width

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -271,7 +271,7 @@ img {
 }
 
 .hero-gallery__image {
-  width: min(100%, 320px);
+  width: 100%;
   aspect-ratio: 3 / 4;
   object-fit: contain;
   border-radius: calc(var(--radius-medium) - 4px);


### PR DESCRIPTION
## Summary
- expand the hero gallery main image to consume the full width of its container
- retain the defined aspect ratio so the enlarged image keeps its proportions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d14ba8c8d083328a8010ba0ade5604