### PR TITLE
Refine layout and add summary bar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
         <nav class="nav" aria-label="Primary">
           <a class="brand" href="#top">Merrimore</a>
           <ul class="nav__links">
-            <li><a href="#promise">Our Promise</a></li>
+            <li><a href="#highlights">Our Promise</a></li>
             <li><a href="#shop">Shop</a></li>
             <li><a href="#nutrition">Nutrition</a></li>
             <li><a href="#community">Community</a></li>
@@ -42,161 +42,162 @@
               <a class="button button--primary" href="#shop">Shop best sellers</a>
               <a class="button button--ghost" href="#nutrition">See our standards</a>
             </div>
-            <div class="hero__stats">
-              <div class="stat-card">
-                <strong>72%</strong>
-                <span>of Merrimore pets show shinier coats within 30 days.</span>
-              </div>
-              <div class="stat-card">
-                <strong>48 hrs</strong>
-                <span>from kitchen to doorstep with insulated, eco-friendly packaging.</span>
-              </div>
-              <div class="stat-card">
-                <strong>100%</strong>
-                <span>recyclable containers and carbon-neutral deliveries.</span>
-              </div>
-            </div>
           </div>
-          <div class="hero__media" aria-hidden="true">
+          <figure class="hero__media">
             <img
               src="https://images.unsplash.com/photo-1546525848-3ce03ca516f6?auto=format&fit=crop&w=1200&q=80"
               alt="Happy dog and cat sharing Merrimore pet food"
             />
-          </div>
+            <figcaption>Happy companions enjoying Merrimore's freshly prepared meal set.</figcaption>
+          </figure>
         </section>
+      </div>
+      <div class="summary-bar">
+        <div class="container">
+          <div class="summary-bar__inner" role="list">
+            <span class="summary-chip" role="listitem">100% 自然脫落來源</span>
+            <span class="summary-chip" role="listitem">三重清潔與蒸氣殺菌</span>
+            <span class="summary-chip" role="listitem">0 添加香料與防腐劑</span>
+          </div>
+        </div>
       </div>
     </header>
 
     <main>
-      <section id="promise" class="section section--light">
+      <section id="highlights" class="section section--light">
         <div class="container">
-          <div class="section__heading">
-            <h2>Food they crave, nutrition you can trust.</h2>
+          <h2 class="section-title">產品亮點 Product Highlights</h2>
+          <div class="section__intro">
             <p>
-              Our kitchens partner with veterinary nutritionists to craft balanced
-              recipes using transparent sourcing and whole ingredients that keep
-              pets energized from playtime to naptime.
+              Our kitchens partner with veterinary nutritionists to craft balanced recipes
+              using transparent sourcing and whole ingredients that keep pets energized from
+              playtime to naptime.
+            </p>
+            <p>
+              Every box is slow-cooked, flash-frozen, and sealed for peak flavor so the meal
+              in your bowl tastes as if it just left our kettles.
             </p>
           </div>
-          <div class="features">
-            <article class="feature-card">
-              <svg width="48" height="48" viewBox="0 0 48 48" fill="none" aria-hidden="true">
-                <rect x="4" y="8" width="40" height="28" rx="14" stroke="#f26a2e" stroke-width="2.5" />
-                <path d="M18 21l6 6 12-12" stroke="#f26a2e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
-              </svg>
-              <h3>Veterinary approved</h3>
-              <p>
-                Board-certified nutritionists review every recipe to ensure
-                balanced protein, fats, and micronutrients for all life stages.
-              </p>
+          <div class="card-grid" role="list">
+            <article class="info-card" role="listitem">
+              <span class="info-card__icon" aria-hidden="true">🩺</span>
+              <h3>Veterinary Approved</h3>
+              <p>Board-certified experts balance protein, fats, and micronutrients for every life stage.</p>
             </article>
-            <article class="feature-card">
-              <svg width="48" height="48" viewBox="0 0 48 48" fill="none" aria-hidden="true">
-                <path
-                  d="M10 16c0-4.418 6.268-8 14-8s14 3.582 14 8-6.268 8-14 8-14 3.582-14 8 6.268 8 14 8 14-3.582 14-8"
-                  stroke="#f26a2e"
-                  stroke-width="2.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <path d="M24 8v32" stroke="#f26a2e" stroke-width="2.5" stroke-linecap="round" />
-              </svg>
-              <h3>Slow cooked &amp; frozen</h3>
-              <p>
-                Gently prepared to lock in taste and texture, then frozen fresh to
-                preserve nutrients without preservatives.
-              </p>
+            <article class="info-card" role="listitem">
+              <span class="info-card__icon" aria-hidden="true">❄️</span>
+              <h3>Slow Cooked &amp; Frozen</h3>
+              <p>Recipes are gently cooked, then frozen to preserve peak texture without preservatives.</p>
             </article>
-            <article class="feature-card">
-              <svg width="48" height="48" viewBox="0 0 48 48" fill="none" aria-hidden="true">
-                <path
-                  d="M8 34c6-4 10-10 16-10s10 6 16 10"
-                  stroke="#f26a2e"
-                  stroke-width="2.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <circle cx="16" cy="16" r="4" stroke="#f26a2e" stroke-width="2.5" />
-                <circle cx="32" cy="16" r="4" stroke="#f26a2e" stroke-width="2.5" />
-              </svg>
-              <h3>Made for sensitive tummies</h3>
-              <p>
-                Functional superfoods like pumpkin, turmeric, and chia support
-                digestion and happy bellies.
-              </p>
+            <article class="info-card" role="listitem">
+              <span class="info-card__icon" aria-hidden="true">🌿</span>
+              <h3>Sensitive-Tummy Safe</h3>
+              <p>Functional superfoods like pumpkin and chia nurture digestion and calm bellies.</p>
             </article>
           </div>
-          <ul class="pill-list" aria-label="Recipe highlights">
-            <li class="pill">Human-grade meats</li>
-            <li class="pill">Seasonal vegetables</li>
-            <li class="pill">No fillers or dyes</li>
-            <li class="pill">AAFCO-compliant</li>
-          </ul>
         </div>
       </section>
 
       <section id="shop" class="section">
         <div class="container">
-          <div class="section__heading">
-            <h2>Best sellers loved by discerning pets.</h2>
+          <h2 class="section-title">規格選購 Signature Selection</h2>
+          <div class="section__intro">
             <p>
-              Build a custom box with chef-crafted recipes, crunchy treats, and
-              supplements tailored to your pet's needs.
+              Build a custom box with chef-crafted recipes, crunchy treats, and supplements tailored to
+              your pet's appetite and routine. Each option is portioned for easy serve-and-store days.
             </p>
           </div>
           <div class="product-grid" role="list">
             <article class="product-card" role="listitem">
-              <img
-                src="https://images.unsplash.com/photo-1617896851807-0ecdbd1229d4?auto=format&fit=crop&w=800&q=80"
-                alt="Bowl of Merrimore chicken and sweet potato meal"
-              />
+              <figure>
+                <img
+                  src="https://images.unsplash.com/photo-1617896851807-0ecdbd1229d4?auto=format&fit=crop&w=800&q=80"
+                  alt="Bowl of Merrimore chicken and sweet potato meal"
+                />
+                <figcaption>Harvest Chicken &amp; Sweet Potato meal trays ready to serve.</figcaption>
+              </figure>
               <h3>Harvest Chicken &amp; Sweet Potato</h3>
-              <p>Lean chicken, beta-carotene rich sweet potatoes, and kale.</p>
+              <p>Lean chicken, beta-carotene sweet potatoes, kale, and golden turmeric.</p>
               <span class="price">$34 / 6-pack trays</span>
             </article>
             <article class="product-card" role="listitem">
-              <img
-                src="https://images.unsplash.com/photo-1601758228041-f3b2795255f1?auto=format&fit=crop&w=800&q=80"
-                alt="Salmon meal toppers in a scoop"
-              />
+              <figure>
+                <img
+                  src="https://images.unsplash.com/photo-1601758228041-f3b2795255f1?auto=format&fit=crop&w=800&q=80"
+                  alt="Salmon meal toppers in a scoop"
+                />
+                <figcaption>Omega Salmon Topper adds glossy-coat nutrition to any bowl.</figcaption>
+              </figure>
               <h3>Omega Salmon Topper</h3>
-              <p>Wild-caught salmon flakes with flaxseed and kelp boosters.</p>
+              <p>Wild-caught salmon flakes, flaxseed, and kelp boosters for daily shine.</p>
               <span class="price">$18 / 12 oz pouch</span>
             </article>
             <article class="product-card" role="listitem">
-              <img
-                src="https://images.unsplash.com/photo-1558944351-cd118865250c?auto=format&fit=crop&w=800&q=80"
-                alt="Assortment of Merrimore freeze-dried treats"
-              />
+              <figure>
+                <img
+                  src="https://images.unsplash.com/photo-1558944351-cd118865250c?auto=format&fit=crop&w=800&q=80"
+                  alt="Assortment of Merrimore freeze-dried treats"
+                />
+                <figcaption>Freeze-dried sampler featuring single-ingredient treats.</figcaption>
+              </figure>
               <h3>Freeze-Dried Treat Variety</h3>
-              <p>Crisp bites of beef liver, chicken heart, and apple slices.</p>
+              <p>Crisp beef liver, chicken heart, and apple slices for mindful rewards.</p>
               <span class="price">$24 / 3-pack</span>
             </article>
             <article class="product-card" role="listitem">
-              <img
-                src="https://images.unsplash.com/photo-1589923188900-85dae523342b?auto=format&fit=crop&w=800&q=80"
-                alt="Probiotic supplement powder"
-              />
+              <figure>
+                <img
+                  src="https://images.unsplash.com/photo-1589923188900-85dae523342b?auto=format&fit=crop&w=800&q=80"
+                  alt="Probiotic supplement powder"
+                />
+                <figcaption>Daily Digestive Booster powder for sensitive stomachs.</figcaption>
+              </figure>
               <h3>Daily Digestive Booster</h3>
-              <p>Probiotics, prebiotic fiber, and chamomile for calm stomachs.</p>
+              <p>Prebiotic fiber, active probiotics, and chamomile for calm digestion.</p>
               <span class="price">$22 / 60 servings</span>
             </article>
           </div>
         </div>
       </section>
 
-      <section id="nutrition" class="section section--light">
+      <section id="process" class="section section--light">
         <div class="container">
+          <h2 class="section-title">了解流程 Our Care Process</h2>
+          <div class="section__intro">
+            <p>
+              From sourcing to delivery, we keep every step in-house for consistent quality. Each
+              shipment is packed in recyclable insulation with temperature trackers you can scan.
+            </p>
+          </div>
+          <div class="card-grid" role="list">
+            <article class="info-card" role="listitem">
+              <span class="info-card__icon" aria-hidden="true">1</span>
+              <h3>Sourcing &amp; Prep</h3>
+              <p>Locally raised proteins and seasonal produce arrive daily for immediate washing.</p>
+            </article>
+            <article class="info-card" role="listitem">
+              <span class="info-card__icon" aria-hidden="true">2</span>
+              <h3>Small-Batch Cooking</h3>
+              <p>Recipes simmer low and slow before rapid chilling locks in nutrients and texture.</p>
+            </article>
+            <article class="info-card" role="listitem">
+              <span class="info-card__icon" aria-hidden="true">3</span>
+              <h3>Cold-Chain Delivery</h3>
+              <p>Insulated boxes ship within 48 hours and arrive ready to store or thaw.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="nutrition" class="section">
+        <div class="container">
+          <h2 class="section-title">了解來源 Ingredient Transparency</h2>
           <div class="split">
-            <div>
-              <div class="section__heading">
-                <h2>The Merrimore standard of care.</h2>
-                <p>
-                  We handle every order in our own temperature-controlled kitchen
-                  and cold chain, so the meals arriving at your door taste just as
-                  fresh as they did on the prep table.
-                </p>
-              </div>
+            <div class="reading-column">
+              <p>
+                We handle every order in our own temperature-controlled kitchen and cold chain so the
+                meals arriving at your door taste just as fresh as they did on the prep table.
+              </p>
               <ul class="badge-list">
                 <li class="badge-item">
                   <span class="badge-icon" aria-hidden="true">&#10003;</span>
@@ -204,8 +205,7 @@
                 </li>
                 <li class="badge-item">
                   <span class="badge-icon" aria-hidden="true">&#10003;</span>
-                  Subscription pauses anytime—skip, swap flavors, or donate to a
-                  local rescue in one click.
+                  Subscription pauses anytime—skip, swap flavors, or donate to a local rescue in one click.
                 </li>
                 <li class="badge-item">
                   <span class="badge-icon" aria-hidden="true">&#10003;</span>
@@ -218,6 +218,7 @@
                 src="https://images.unsplash.com/photo-1513105737059-ff0cf0580e0a?auto=format&fit=crop&w=1000&q=80"
                 alt="Chef portioning Merrimore pet meals"
               />
+              <figcaption>Chef-led team portions Merrimore meals in a temperature-controlled kitchen.</figcaption>
             </figure>
           </div>
         </div>
@@ -226,12 +227,13 @@
       <section id="subscribe" class="section">
         <div class="container">
           <div class="subscription">
-            <h2>Join the Merrimore Meal Club.</h2>
-            <p>
-              Choose a plan that matches your pet's size and schedule. We'll prep,
-              pack, and deliver ready-to-serve meals on your cadence with flexible
-              shipping windows.
-            </p>
+            <h2 class="section-title">加入餐盒訂閱 Meal Club</h2>
+            <div class="section__intro">
+              <p>
+                Choose a plan that matches your pet's size and schedule. We'll prep, pack, and deliver
+                ready-to-serve meals on your cadence with flexible shipping windows.
+              </p>
+            </div>
             <div class="hero__actions">
               <a class="button button--primary" href="#shop">Build your box</a>
               <a class="button button--ghost" href="mailto:care@merrimore.com">Chat with nutrition</a>
@@ -247,11 +249,11 @@
 
       <section id="stories" class="section section--light">
         <div class="container">
-          <div class="section__heading">
-            <h2>Pet parents are seeing the difference.</h2>
+          <h2 class="section-title">真實回饋 Community Stories</h2>
+          <div class="section__intro">
             <p>
-              From energy levels to digestion, Merrimore families share the wins
-              they notice after switching to our recipes.
+              From energy levels to digestion, Merrimore families share the wins they notice after switching
+              to our recipes.
             </p>
           </div>
           <div class="testimonials">
@@ -283,11 +285,10 @@
 
       <section id="community" class="section">
         <div class="container">
-          <div class="section__heading">
-            <h2>Community bowls &amp; resources.</h2>
+          <h2 class="section-title">社群資源 Community Bowls</h2>
+          <div class="section__intro">
             <p>
-              Explore ideas for enrichment, training, and seasonal recipes from
-              our Merrimore pack leaders.
+              Explore ideas for enrichment, training, and seasonal recipes from our Merrimore pack leaders.
             </p>
           </div>
           <div class="community">
@@ -326,13 +327,17 @@
         <div class="container">
           <div class="split">
             <div>
-              <h2>Visit our neighborhood market.</h2>
-              <p>
-                Stop by Merrimore Market for same-day pick up, custom treat bars,
-                and fittings for collars, beds, and wellness essentials.
-              </p>
+              <h2 class="section-title">到門市走走 Visit Merrimore Market</h2>
+              <div class="section__intro">
+                <p>
+                  Stop by Merrimore Market for same-day pick up, custom treat bars, and fittings for collars,
+                  beds, and wellness essentials.
+                </p>
+              </div>
               <div class="hero__actions">
-                <a class="button button--primary" href="https://maps.google.com" target="_blank" rel="noopener">Plan your visit</a>
+                <a class="button button--primary" href="https://maps.google.com" target="_blank" rel="noopener">
+                  Plan your visit
+                </a>
                 <a class="button button--ghost" href="tel:+18885551212">Call (888) 555-1212</a>
               </div>
             </div>
@@ -341,6 +346,7 @@
                 src="https://images.unsplash.com/photo-1620744738794-a4c4edfb883c?auto=format&fit=crop&w=1000&q=80"
                 alt="Merrimore retail market with pet products"
               />
+              <figcaption>Merrimore Market stocks fresh meals, gear, and seasonal wellness picks.</figcaption>
             </figure>
           </div>
         </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -15,6 +15,7 @@
   --radius-medium: 20px;
   --radius-small: 12px;
   --max-width: 1180px;
+  --reading-width: 70ch;
   font-family: 'Manrope', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
 }
 
@@ -33,7 +34,7 @@ body {
     linear-gradient(180deg, rgba(245, 249, 241, 0.95) 0%, rgba(228, 242, 214, 0.85) 45%, rgba(245, 249, 241, 0.95) 100%);
   background-color: var(--color-bg);
   color: var(--color-ink);
-  line-height: 1.6;
+  line-height: 1.7;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -51,12 +52,78 @@ img {
   max-width: 100%;
   border-radius: var(--radius-medium);
   display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+figure {
+  margin: 0;
+}
+
+figcaption {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .container {
   max-width: var(--max-width);
   margin: 0 auto;
   padding: 0 clamp(1.25rem, 4vw, 3rem);
+}
+
+.reading-column {
+  max-width: var(--reading-width);
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.reading-column p,
+.reading-column ul,
+.reading-column ol {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.reading-column > * + * {
+  margin-top: 0;
+}
+
+.split .reading-column {
+  margin-inline: 0;
+}
+
+h2,
+h3,
+p,
+ul,
+ol {
+  margin: 0;
+}
+
+p + p {
+  margin-top: 1.25rem;
+}
+
+h2 {
+  color: var(--color-secondary);
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin-top: clamp(4rem, 9vw, 6rem);
+  margin-bottom: 1.5rem;
+}
+
+h3 {
+  color: var(--color-secondary);
+  font-size: clamp(1.25rem, 2.4vw, 1.6rem);
+  margin-bottom: 0.75rem;
+}
+
+.section-title {
+  margin-top: clamp(4rem, 9vw, 6.25rem);
+  margin-bottom: 1.5rem;
 }
 
 .site-header {
@@ -162,6 +229,10 @@ img {
 .hero__copy {
   position: relative;
   z-index: 1;
+  max-width: var(--reading-width);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .hero__eyebrow {
@@ -189,34 +260,13 @@ img {
 .hero p {
   font-size: 1.05rem;
   color: var(--color-muted);
-  max-width: 520px;
 }
 
 .hero__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  margin-top: 2rem;
-}
-
-.hero__stats {
-  display: grid;
-  gap: 1.25rem;
-  margin-top: clamp(2.5rem, 5vw, 4rem);
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-.stat-card {
-  background: rgba(244, 205, 65, 0.12);
-  border-radius: var(--radius-medium);
-  padding: 1.25rem 1.5rem;
-  border: 1px solid rgba(127, 191, 76, 0.12);
-}
-
-.stat-card strong {
-  display: block;
-  font-size: 1.4rem;
-  color: var(--color-secondary);
+  margin-top: 0.5rem;
 }
 
 .hero__media {
@@ -225,6 +275,59 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hero__media img {
+  aspect-ratio: 4 / 3;
+  object-position: center;
+}
+
+.hero__media figcaption {
+  text-align: center;
+}
+
+.summary-bar {
+  margin-top: clamp(2rem, 5vw, 3rem);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(245, 249, 241, 0.95);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.summary-bar__inner {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  padding: 1rem 0;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+}
+
+.summary-chip {
+  flex: 1 1 240px;
+  min-width: 220px;
+  border-radius: var(--radius-small);
+  border: 1px solid rgba(31, 76, 70, 0.14);
+  background: rgba(255, 255, 255, 0.85);
+  padding: 1rem 1.25rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+  scroll-snap-align: start;
+  white-space: nowrap;
+}
+
+@media (min-width: 768px) {
+  .summary-bar__inner {
+    overflow: visible;
+  }
+
+  .summary-chip {
+    white-space: normal;
+  }
 }
 
 .hero-gallery {
@@ -337,25 +440,71 @@ img {
   padding: clamp(3.5rem, 8vw, 6rem) 0;
 }
 
-.section__heading {
-  max-width: 620px;
-  margin-bottom: clamp(2.5rem, 6vw, 4rem);
-}
-
-.section__heading h2 {
-  margin: 0 0 1rem;
-  font-size: clamp(2rem, 4vw, 2.8rem);
-  color: var(--color-secondary);
-}
-
-.section__heading p {
-  margin: 0;
-  color: var(--color-muted);
-  font-size: 1.05rem;
-}
-
 .section--light {
   background: rgba(255, 255, 255, 0.78);
+}
+
+.section__intro {
+  max-width: var(--reading-width);
+  margin-inline: auto;
+  color: var(--color-muted);
+  font-size: 1.05rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: left;
+}
+
+.container > .section-title:first-child,
+.subscription > .section-title {
+  margin-top: 0;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1fr;
+  margin-top: clamp(2rem, 5vw, 3rem);
+}
+
+@media (min-width: 768px) {
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.info-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-medium);
+  padding: 2rem;
+  box-shadow: var(--shadow-card);
+  border: 1px solid rgba(31, 76, 70, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.info-card__icon {
+  width: 3rem;
+  height: 3rem;
+  display: grid;
+  place-items: center;
+  background: rgba(127, 191, 76, 0.18);
+  border-radius: 999px;
+  color: var(--color-secondary);
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.info-card p {
+  color: var(--color-muted);
+  margin: 0;
 }
 
 .product-gallery {
@@ -641,6 +790,14 @@ img {
   padding: clamp(3rem, 6vw, 4.5rem);
   position: relative;
   overflow: hidden;
+}
+
+.subscription .section__intro {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.subscription .section__intro p {
+  color: inherit;
 }
 
 .subscription::after {


### PR DESCRIPTION
## Summary
- restructured the hero area with a sticky summary bar and consistent figure captions for imagery
- limited copy blocks to a 70-character reading width and refreshed section intros and headings
- converted highlights and process sections into responsive info cards and added captions to product imagery

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d14dbff4a08332b8f65545e543c554