### PR TITLE
feat: add product CRUD API

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import morgan from 'morgan';
 import env from './config/env';
 import healthRouter from './routes/health';
+import productsRouter from './routes/products';
 
 export const createApp = () => {
   const app = express();
@@ -10,6 +11,7 @@ export const createApp = () => {
   app.use(cors());
   app.use(express.json());
   app.use(morgan(env.nodeEnv === 'production' ? 'combined' : 'dev'));
+  app.use('/uploads', express.static(env.uploadDir));
 
   app.get('/api', (_req, res) => {
     res.json({
@@ -20,6 +22,7 @@ export const createApp = () => {
   });
 
   app.use('/api/health', healthRouter);
+  app.use('/api/products', productsRouter);
 
   return app;
 };

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -1,13 +1,19 @@
+import path from 'path';
 import dotenv from 'dotenv';
 
 dotenv.config();
+
+const serverRoot = path.resolve(__dirname, '..', '..');
+const resolvedUploadDir = process.env.UPLOAD_DIR
+  ? path.resolve(serverRoot, process.env.UPLOAD_DIR)
+  : path.resolve(serverRoot, 'uploads');
 
 const env = {
   nodeEnv: process.env.NODE_ENV ?? 'development',
   port: Number(process.env.PORT ?? 3000),
   databaseUrl: process.env.DATABASE_URL ?? '',
   jwtSecret: process.env.JWT_SECRET ?? 'change-me',
-  uploadDir: process.env.UPLOAD_DIR ?? 'uploads',
+  uploadDir: resolvedUploadDir,
 };
 
 export default env;

--- a/server/src/models/product.ts
+++ b/server/src/models/product.ts
@@ -1,0 +1,26 @@
+export interface Product {
+  id: string;
+  name: string;
+  description?: string;
+  price: number;
+  imageUrl?: string;
+  stock: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type CreateProductInput = {
+  name: string;
+  description?: string;
+  price: number;
+  imageUrl?: string;
+  stock?: number;
+};
+
+export type UpdateProductInput = {
+  name: string;
+  description?: string;
+  price: number;
+  imageUrl?: string | null;
+  stock?: number;
+};

--- a/server/src/routes/products.ts
+++ b/server/src/routes/products.ts
@@ -1,0 +1,176 @@
+import fs from 'fs';
+import path from 'path';
+import express from 'express';
+import multer from 'multer';
+import env from '../config/env';
+import productsStore from '../store/productsStore';
+
+const router = express.Router();
+
+fs.mkdirSync(env.uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, env.uploadDir);
+  },
+  filename: (_req, file, cb) => {
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    const extension = path.extname(file.originalname);
+    cb(null, `${uniqueSuffix}${extension}`);
+  },
+});
+
+const upload = multer({ storage });
+
+const buildImageUrl = (filename: string) => `/uploads/${filename}`;
+
+const parseNumberField = (value: unknown, fieldName: string) => {
+  const parsed = Number(value ?? 0);
+
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${fieldName} must be a number`);
+  }
+
+  return parsed;
+};
+
+const removeImageFile = async (imageUrl?: string) => {
+  if (!imageUrl) {
+    return;
+  }
+
+  const filename = path.basename(imageUrl);
+  const filePath = path.join(env.uploadDir, filename);
+
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};
+
+const removeUploadedFile = async (file?: { path: string } | null) => {
+  if (!file) {
+    return;
+  }
+
+  try {
+    await fs.promises.unlink(file.path);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};
+
+router.get('/', (_req, res) => {
+  const products = productsStore.getAll();
+  res.json(products);
+});
+
+router.post('/', upload.single('image'), async (req, res) => {
+  const { name, description, price, stock } = req.body;
+
+  if (!name || price === undefined) {
+    return res.status(400).json({ message: 'name and price are required' });
+  }
+
+  let parsedPrice: number;
+  let parsedStock: number;
+
+  try {
+    parsedPrice = parseNumberField(price, 'price');
+    parsedStock = parseNumberField(stock ?? 0, 'stock');
+  } catch (error) {
+    return res.status(400).json({ message: (error as Error).message });
+  }
+
+  const imageUrl = req.file ? buildImageUrl(req.file.filename) : undefined;
+
+  const product = productsStore.create({
+    name,
+    description,
+    price: parsedPrice,
+    stock: parsedStock,
+    imageUrl,
+  });
+
+  return res.status(201).json(product);
+});
+
+router.put('/:id', upload.single('image'), async (req, res) => {
+  const { id } = req.params;
+  const existing = productsStore.findById(id);
+
+  if (!existing) {
+    await removeUploadedFile(req.file);
+    return res.status(404).json({ message: 'Product not found' });
+  }
+
+  const { name, description, price, stock } = req.body;
+
+  if (!name || price === undefined) {
+    await removeUploadedFile(req.file);
+    return res.status(400).json({ message: 'name and price are required' });
+  }
+
+  let parsedPrice: number;
+  let parsedStock: number;
+
+  try {
+    parsedPrice = parseNumberField(price, 'price');
+    parsedStock = parseNumberField(stock ?? existing.stock, 'stock');
+  } catch (error) {
+    await removeUploadedFile(req.file);
+    return res.status(400).json({ message: (error as Error).message });
+  }
+
+  let newImageUrl: string | undefined;
+
+  if (req.file) {
+    newImageUrl = buildImageUrl(req.file.filename);
+    try {
+      await removeImageFile(existing.imageUrl);
+    } catch (error) {
+      return res.status(500).json({ message: 'Failed to update product image' });
+    }
+  }
+
+  const updated = productsStore.update(id, {
+    name,
+    description,
+    price: parsedPrice,
+    stock: parsedStock,
+    imageUrl: req.file ? newImageUrl : undefined,
+  });
+
+  if (!updated) {
+    return res.status(404).json({ message: 'Product not found' });
+  }
+
+  return res.json(updated);
+});
+
+router.delete('/:id', async (req, res) => {
+  const { id } = req.params;
+
+  const removed = productsStore.delete(id);
+
+  if (!removed) {
+    return res.status(404).json({ message: 'Product not found' });
+  }
+
+  try {
+    await removeImageFile(removed.imageUrl);
+  } catch (error) {
+    return res.status(500).json({ message: 'Failed to delete product image' });
+  }
+
+  return res.status(204).send();
+});
+
+export default router;

--- a/server/src/store/productsStore.ts
+++ b/server/src/store/productsStore.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from 'crypto';
+import { CreateProductInput, Product, UpdateProductInput } from '../models/product';
+
+class ProductsStore {
+  private products: Product[] = [];
+
+  getAll() {
+    return this.products;
+  }
+
+  create(input: CreateProductInput) {
+    const now = new Date();
+    const product: Product = {
+      id: randomUUID(),
+      name: input.name,
+      description: input.description,
+      price: input.price,
+      imageUrl: input.imageUrl,
+      stock: input.stock ?? 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.products.push(product);
+    return product;
+  }
+
+  update(id: string, input: UpdateProductInput) {
+    const index = this.products.findIndex((product) => product.id === id);
+
+    if (index === -1) {
+      return null;
+    }
+
+    const existing = this.products[index];
+    const updated: Product = {
+      ...existing,
+      name: input.name,
+      description: input.description ?? existing.description,
+      price: input.price,
+      imageUrl: input.imageUrl === null ? undefined : input.imageUrl ?? existing.imageUrl,
+      stock: input.stock ?? existing.stock,
+      updatedAt: new Date(),
+    };
+
+    this.products[index] = updated;
+    return updated;
+  }
+
+  delete(id: string) {
+    const index = this.products.findIndex((product) => product.id === id);
+
+    if (index === -1) {
+      return null;
+    }
+
+    const [removed] = this.products.splice(index, 1);
+    return removed;
+  }
+
+  findById(id: string) {
+    return this.products.find((product) => product.id === id) ?? null;
+  }
+
+  clear() {
+    this.products = [];
+  }
+}
+
+const productsStore = new ProductsStore();
+
+export default productsStore;
+export { ProductsStore };

--- a/tests/products.test.ts
+++ b/tests/products.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { once } from 'node:events';
+import type { Server } from 'node:http';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import env from '../server/src/config/env';
+import createApp from '../server/src/app';
+import productsStore from '../server/src/store/productsStore';
+
+const cleanupUploads = async () => {
+  try {
+    const entries = await fs.promises.readdir(env.uploadDir);
+    await Promise.all(
+      entries.map((entry) => fs.promises.unlink(path.join(env.uploadDir, entry)))
+    );
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};
+
+describe('Products API', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    productsStore.clear();
+    await cleanupUploads();
+
+    const app = createApp();
+    server = app.listen(0);
+    await once(server, 'listening');
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Unable to determine server address');
+    }
+
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      server.close();
+      await once(server, 'close');
+    }
+
+    await cleanupUploads();
+  });
+
+  it('returns an empty array when no products exist', async () => {
+    const response = await fetch(`${baseUrl}/api/products`);
+    assert.equal(response.status, 200);
+
+    const data = (await response.json()) as unknown[];
+    assert.equal(Array.isArray(data), true);
+    assert.equal(data.length, 0);
+  });
+
+  it('rejects creating a product without required fields', async () => {
+    const formData = new FormData();
+    formData.set('description', 'Missing name and price');
+
+    const response = await fetch(`${baseUrl}/api/products`, {
+      method: 'POST',
+      body: formData,
+    });
+
+    assert.equal(response.status, 400);
+    const body = (await response.json()) as { message: string };
+    assert.match(body.message, /name and price are required/);
+  });
+
+  it('creates, updates, and deletes a product successfully', async () => {
+    const formData = new FormData();
+    formData.set('name', 'Test Product');
+    formData.set('description', 'A product for testing');
+    formData.set('price', '19.99');
+    formData.set('stock', '5');
+    formData.set('image', new Blob(['test-image'], { type: 'image/png' }), 'test.png');
+
+    const createResponse = await fetch(`${baseUrl}/api/products`, {
+      method: 'POST',
+      body: formData,
+    });
+
+    assert.equal(createResponse.status, 201);
+    const created = (await createResponse.json()) as {
+      id: string;
+      name: string;
+      price: number;
+      imageUrl?: string;
+      stock: number;
+    };
+
+    assert.ok(created.id);
+    assert.equal(created.name, 'Test Product');
+    assert.equal(created.price, 19.99);
+    assert.equal(created.stock, 5);
+    assert.ok(created.imageUrl?.startsWith('/uploads/'));
+
+    if (created.imageUrl) {
+      const filePath = path.join(env.uploadDir, path.basename(created.imageUrl));
+      assert.equal(fs.existsSync(filePath), true);
+    }
+
+    const updateForm = new FormData();
+    updateForm.set('name', 'Updated Product');
+    updateForm.set('price', '29.99');
+    updateForm.set('stock', '2');
+
+    const updateResponse = await fetch(`${baseUrl}/api/products/${created.id}`, {
+      method: 'PUT',
+      body: updateForm,
+    });
+
+    assert.equal(updateResponse.status, 200);
+    const updated = (await updateResponse.json()) as {
+      id: string;
+      name: string;
+      price: number;
+      stock: number;
+    };
+
+    assert.equal(updated.name, 'Updated Product');
+    assert.equal(updated.price, 29.99);
+    assert.equal(updated.stock, 2);
+
+    const deleteResponse = await fetch(`${baseUrl}/api/products/${created.id}`, {
+      method: 'DELETE',
+    });
+
+    assert.equal(deleteResponse.status, 204);
+
+    const listResponse = await fetch(`${baseUrl}/api/products`);
+    const list = (await listResponse.json()) as unknown[];
+    assert.equal(list.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a product model with an in-memory store for managing product data
- implement /api/products CRUD endpoints with multer-based image uploads and basic validation
- expose uploads as static assets and add Node test coverage for the products API

## Testing
- Not Run (npm install fails with 403 Forbidden when downloading packages from registry)

------
https://chatgpt.com/codex/tasks/task_e_68d3631c1d788332a4e2485c8cba188e