### PR TITLE
Add product lookup endpoint and tests

### DIFF
--- a/server/src/routes/products.ts
+++ b/server/src/routes/products.ts
@@ -93,6 +93,21 @@ router.get('/', (_req: express.Request, res: express.Response) => {
   response.json(products);
 });
 
+router.get('/:id', (req: express.Request, res: express.Response) => {
+  const request = asProductRequest(req);
+  const response = asResponse(res);
+  const params = request.params as Record<string, string>;
+  const { id } = params;
+
+  const product = productsStore.findById(id);
+
+  if (!product) {
+    return response.status(404).json({ message: 'Product not found' });
+  }
+
+  return response.json(product);
+});
+
 router.post('/', requireAdmin, upload.single('image'), async (req: express.Request, res: express.Response) => {
   const request = asProductRequest(req);
   const response = asResponse(res);


### PR DESCRIPTION
## Summary
- add a GET /api/products/:id route that returns the stored product or a 404 error payload
- extend the products API tests to cover successful lookup, 404 responses, and authenticated admin flows

## Testing
- ./server/node_modules/.bin/tsx --test tests/products.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d3a43cfb688332a5a25e5842d15327