### PR TITLE
Handle missing multer file paths when cleaning up

### DIFF
--- a/server/src/routes/products.ts
+++ b/server/src/routes/products.ts
@@ -72,13 +72,26 @@ const removeImageFile = async (imageUrl?: string) => {
   }
 };
 
-const removeUploadedFile = async (file?: { path: string } | null) => {
+const removeUploadedFile = async (file?: MulterFile | null) => {
   if (!file) {
     return;
   }
 
+  let filePath = file.path;
+
+  if (!filePath) {
+    const { filename } = file;
+    const destination = file.destination ?? env.uploadDir;
+
+    if (!filename || !destination) {
+      return;
+    }
+
+    filePath = path.join(destination, filename);
+  }
+
   try {
-    await fs.promises.unlink(file.path);
+    await fs.promises.unlink(filePath);
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
     if (err.code !== 'ENOENT') {


### PR DESCRIPTION
## Summary
- derive the cleanup path for uploaded files from available multer metadata
- skip unlinking when required path information is unavailable while preserving ENOENT handling

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3b40c26048332884cbd9c8effb10d