### PR TITLE
test: repair products api integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shopping-cart-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node ./server/node_modules/tsx/dist/cli.mjs --test tests/products.test.ts"
+  }
+}


### PR DESCRIPTION
## Summary
- rewrite the products API integration tests to remove merge artefacts and exercise the admin login flow
- add a repository level npm test script that runs the TypeScript tests via the server's tsx installation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d3b533ba2c8332a6b245b2655cb8bf