### PR TITLE
Fix env config defaults

### DIFF
--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -14,10 +14,12 @@ const resolvedUploadDir = process.env.UPLOAD_DIR
   : path.resolve(serverRoot, 'uploads');
 
 const env = {
-  nodeEnv: process.env.NODE_ENV 'production',
+  nodeEnv: process.env.NODE_ENV ?? 'production',
   port: Number(process.env.PORT ?? 3000),
-  databaseUrl: process.env.DATABASE_URL 'mongodb+srv://raymondckm2000_db_user:NYKpt9WEEYEU15OF@cluster0.hyxlahl.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0',
-  jwtSecret: process.env.JWT_SECRET 'mySuperSecretKey_123!@#',
+  databaseUrl:
+    process.env.DATABASE_URL ??
+    'mongodb+srv://raymondckm2000_db_user:NYKpt9WEEYEU15OF@cluster0.hyxlahl.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0',
+  jwtSecret: process.env.JWT_SECRET ?? 'mySuperSecretKey_123!@#',
   adminUsername: process.env.ADMIN_USERNAME ?? 'admin',
   adminPassword: process.env.ADMIN_PASSWORD ?? 'admin123',
   uploadDir: resolvedUploadDir,


### PR DESCRIPTION
## Summary
- correct the environment configuration defaults to use nullish coalescing operators
- ensure env.ts can be parsed by the test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3c275d0e4833299e8d7e67e49b867