### PR TITLE
fix: enforce DATABASE_URL configuration at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ No local development is required. All code will be generated, updated, and maint
 ---
 
 ## 3. Environment
-Environment variables will be stored on **cloud deployment platforms** only.  
+Environment variables will be stored on **cloud deployment platforms** only.
+
+> **Important:** The backend will refuse to start if `DATABASE_URL` is not supplied. Configure this value in your deployment (or
+> local `.env`) before booting the API.
 
 Example `.env.example` file (committed to repo for reference):  
 PORT=3000
-DATABASE_URL=mongodb+srv://<user>:<pass>@cluster.mongodb.net/shopping_cart
+DATABASE_URL=mongodb+srv://<user>:<pass>@cluster.mongodb.net/shopping_cart # Required
 JWT_SECRET=secret123
 UPLOAD_DIR=uploads
 

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -13,12 +13,28 @@ const resolvedUploadDir = process.env.UPLOAD_DIR
   ? path.resolve(serverRoot, process.env.UPLOAD_DIR)
   : path.resolve(serverRoot, 'uploads');
 
+const getRequiredEnvVar = (key: string): string => {
+  const value = process.env[key];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+
+  return value;
+};
+
+let cachedDatabaseUrl: string | undefined;
+
 const env = {
   nodeEnv: process.env.NODE_ENV ?? 'production',
   port: Number(process.env.PORT ?? 3000),
-  databaseUrl:
-    process.env.DATABASE_URL ??
-    'mongodb+srv://raymondckm2000_db_user:NYKpt9WEEYEU15OF@cluster0.hyxlahl.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0',
+  get databaseUrl(): string {
+    if (cachedDatabaseUrl === undefined) {
+      cachedDatabaseUrl = getRequiredEnvVar('DATABASE_URL');
+    }
+
+    return cachedDatabaseUrl;
+  },
   jwtSecret: process.env.JWT_SECRET ?? 'mySuperSecretKey_123!@#',
   adminUsername: process.env.ADMIN_USERNAME ?? 'admin',
   adminPassword: process.env.ADMIN_PASSWORD ?? 'admin123',

--- a/server/src/config/runtimeChecks.ts
+++ b/server/src/config/runtimeChecks.ts
@@ -10,7 +10,6 @@ export interface StartupCheckResult {
 }
 
 const sensitiveEnvVars: Array<{ key: string; description: string }> = [
-  { key: 'DATABASE_URL', description: 'Database connection string' },
   { key: 'JWT_SECRET', description: 'JWT secret' },
   { key: 'ADMIN_USERNAME', description: 'Admin username' },
   { key: 'ADMIN_PASSWORD', description: 'Admin password' },
@@ -63,6 +62,32 @@ export const performStartupChecks = (): StartupCheckResult[] => {
     status: 'passed',
     message: `Running in \"${env.nodeEnv}\" mode.`,
   });
+
+  try {
+    const databaseUrl = env.databaseUrl;
+    results.push({
+      name: 'env:DATABASE_URL',
+      status: 'passed',
+      message: 'Database connection string provided via environment variable.',
+    });
+
+    if (!databaseUrl.trim()) {
+      results.push({
+        name: 'env:DATABASE_URL format',
+        status: 'warning',
+        message: 'DATABASE_URL is empty after trimming whitespace.',
+      });
+    }
+  } catch (error) {
+    results.push({
+      name: 'env:DATABASE_URL',
+      status: 'failed',
+      message:
+        error instanceof Error
+          ? error.message
+          : 'Missing required environment variable: DATABASE_URL',
+    });
+  }
 
   sensitiveEnvVars.forEach(({ key, description }) => {
     if (!process.env[key]) {


### PR DESCRIPTION
## Summary
- require the DATABASE_URL environment variable in the server config and cache its value
- update the startup checks to fail fast when DATABASE_URL is missing and warn on empty strings
- document the DATABASE_URL requirement in the environment setup instructions

## Testing
- DATABASE_URL=mongodb://localhost/test npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6451a442c8332a2336dcd96ff98fc