### PR TITLE
Fix env configuration validation and clean runtime checks

### DIFF
--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -24,40 +24,21 @@ const resolvedUploadDir = process.env.UPLOAD_DIR
   ? path.resolve(serverRoot, process.env.UPLOAD_DIR)
   : path.resolve(serverRoot, 'uploads');
 
-const getRequiredEnvVar = (key: string): string => {
-  const value = process.env[key];
-
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${key}`);
-  }
-
-  return value;
-};
-
 let cachedDatabaseUrl: string | undefined;
 
 const env = {
   nodeEnv: process.env.NODE_ENV ?? 'production',
   port: Number(process.env.PORT ?? 3000),
-codex/enhance-security-for-admin-credentials
-  databaseUrl:
-    process.env.DATABASE_URL ??
-    'mongodb+srv://raymondckm2000_db_user:NYKpt9WEEYEU15OF@cluster0.hyxlahl.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0',
-  jwtSecret: requireEnv('JWT_SECRET'),
-  adminUsername: requireEnv('ADMIN_USERNAME'),
-  adminPassword: requireEnv('ADMIN_PASSWORD'),
-
   get databaseUrl(): string {
     if (cachedDatabaseUrl === undefined) {
-      cachedDatabaseUrl = getRequiredEnvVar('DATABASE_URL');
+      cachedDatabaseUrl = requireEnv('DATABASE_URL');
     }
 
     return cachedDatabaseUrl;
   },
-  jwtSecret: process.env.JWT_SECRET ?? 'mySuperSecretKey_123!@#',
-  adminUsername: process.env.ADMIN_USERNAME ?? 'admin',
-  adminPassword: process.env.ADMIN_PASSWORD ?? 'admin123',
-main
+  jwtSecret: requireEnv('JWT_SECRET'),
+  adminUsername: requireEnv('ADMIN_USERNAME'),
+  adminPassword: requireEnv('ADMIN_PASSWORD'),
   uploadDir: resolvedUploadDir,
 };
 


### PR DESCRIPTION
## Summary
- resolve merge remnants in the server env configuration and ensure sensitive values use strict requireEnv validation
- rebuild the runtime startup checks to validate database configuration and admin credentials without duplicate definitions

## Testing
- `cd server && JWT_SECRET=test ADMIN_USERNAME=admin ADMIN_PASSWORD=pass DATABASE_URL=mongodb://example npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d648984d788332be7dc3e752c1574a