### PR TITLE
refactor: make DATABASE_URL optional until persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,22 @@ No local development is required. All code will be generated, updated, and maint
 ## 3. Environment
 Environment variables will be stored on **cloud deployment platforms** only.
 
-> **Important:** The backend will refuse to start if `DATABASE_URL` is not supplied. Configure this value in your deployment (or
-> local `.env`) before booting the API.
+> **Important:** Until database persistence is wired up, `DATABASE_URL` is optional. When it is omitted the API runs with in-memory
+> data only, and the startup checks emit a warning instead of blocking the boot process. Provide a valid connection string once
+> you are ready to integrate MongoDB (or another backing store).
+
+To re-enable the strict requirement after the database is connected:
+
+1. Set `DATABASE_URL` in your deployment environment (or local `.env`).
+2. Update `server/src/config/env.ts` so `databaseUrl` once again calls `requireEnv('DATABASE_URL')`.
+3. Adjust the `env:DATABASE_URL` check in `server/src/config/runtimeChecks.ts` to treat a missing value as a failure.
 
 Example `.env.example` file (committed to repo for reference):
 PORT=3000
-codex/enhance-security-for-admin-credentials
-DATABASE_URL=mongodb+srv://<user>:<pass>@cluster.mongodb.net/shopping_cart
+DATABASE_URL=mongodb+srv://<user>:<pass>@cluster.mongodb.net/shopping_cart # Optional until persistence is enabled
 JWT_SECRET=change-me
 ADMIN_USERNAME=change-me
 ADMIN_PASSWORD=change-me
-=======
-DATABASE_URL=mongodb+srv://<user>:<pass>@cluster.mongodb.net/shopping_cart # Required
-JWT_SECRET=secret123
- main
 UPLOAD_DIR=uploads
 
 ⚠️ Do not commit `.env` files with real secrets.

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -19,19 +19,31 @@ const requireEnv = (key: string): string => {
   return value;
 };
 
+const optionalEnv = (key: string): string | undefined => {
+  const value = process.env[key];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : value;
+};
+
 const serverRoot = path.resolve(__dirname, '..', '..');
 const resolvedUploadDir = process.env.UPLOAD_DIR
   ? path.resolve(serverRoot, process.env.UPLOAD_DIR)
   : path.resolve(serverRoot, 'uploads');
 
 let cachedDatabaseUrl: string | undefined;
+let isDatabaseUrlLoaded = false;
 
 const env = {
   nodeEnv: process.env.NODE_ENV ?? 'production',
   port: Number(process.env.PORT ?? 3000),
-  get databaseUrl(): string {
-    if (cachedDatabaseUrl === undefined) {
-      cachedDatabaseUrl = requireEnv('DATABASE_URL');
+  get databaseUrl(): string | undefined {
+    if (!isDatabaseUrlLoaded) {
+      cachedDatabaseUrl = optionalEnv('DATABASE_URL');
+      isDatabaseUrlLoaded = true;
     }
 
     return cachedDatabaseUrl;

--- a/server/src/config/runtimeChecks.ts
+++ b/server/src/config/runtimeChecks.ts
@@ -14,7 +14,7 @@ const sensitiveEnvVars: Array<{
   description: string;
   required: boolean;
 }> = [
-  { key: 'DATABASE_URL', description: 'Database connection string', required: true },
+  { key: 'DATABASE_URL', description: 'Database connection string', required: false },
   { key: 'JWT_SECRET', description: 'JWT secret', required: true },
   { key: 'ADMIN_USERNAME', description: 'Admin username', required: true },
   { key: 'ADMIN_PASSWORD', description: 'Admin password', required: true },
@@ -68,30 +68,30 @@ export const performStartupChecks = (): StartupCheckResult[] => {
     message: `Running in "${env.nodeEnv}" mode.`,
   });
 
-  try {
+  {
     const databaseUrl = env.databaseUrl;
-    results.push({
-      name: 'env:DATABASE_URL',
-      status: 'passed',
-      message: 'Database connection string provided via environment variable.',
-    });
-
-    if (!databaseUrl.trim()) {
+    if (typeof databaseUrl === 'string') {
       results.push({
-        name: 'env:DATABASE_URL format',
+        name: 'env:DATABASE_URL',
+        status: 'passed',
+        message: 'Database connection string provided via environment variable.',
+      });
+
+      if (!databaseUrl.trim()) {
+        results.push({
+          name: 'env:DATABASE_URL format',
+          status: 'warning',
+          message: 'DATABASE_URL is empty after trimming whitespace.',
+        });
+      }
+    } else {
+      results.push({
+        name: 'env:DATABASE_URL',
         status: 'warning',
-        message: 'DATABASE_URL is empty after trimming whitespace.',
+        message:
+          'DATABASE_URL is not set. Persistence-related features remain disabled until a database is configured.',
       });
     }
-  } catch (error) {
-    results.push({
-      name: 'env:DATABASE_URL',
-      status: 'failed',
-      message:
-        error instanceof Error
-          ? error.message
-          : 'Missing required environment variable: DATABASE_URL',
-    });
   }
 
   sensitiveEnvVars


### PR DESCRIPTION
## Summary
- allow the server configuration to tolerate an unset DATABASE_URL while caching the resolved value
- downgrade the startup check for DATABASE_URL to a warning when the variable is missing
- document the temporary optional status and how to restore the requirement once persistence is added

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d653fc10388332927b71a2dfb72959