### PR TITLE
Resolve merge conflicts in server config files

### DIFF
--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -8,21 +8,6 @@ const __dirname = dirname(__filename);
 
 dotenv.config();
 
-const requireEnv = (key: string): string => {
-  const value = process.env[key];
-  if (typeof value !== 'string' || value.trim() === '') {
-    throw new Error(
-      `Missing required environment variable "${key}". Please provide a secure value before starting the server.`,
-    );
-  }
-
-  return value;
-};
-
-codex/update-jwt-config-with-fallback-defaults
-const nodeEnv = process.env.NODE_ENV ?? 'production';
-const isProduction = nodeEnv === 'production';
-=======
 const optionalEnv = (key: string): string | undefined => {
   const value = process.env[key];
   if (typeof value !== 'string') {
@@ -32,7 +17,9 @@ const optionalEnv = (key: string): string | undefined => {
   const trimmed = value.trim();
   return trimmed === '' ? undefined : value;
 };
- main
+
+const nodeEnv = process.env.NODE_ENV ?? 'production';
+const isProduction = nodeEnv === 'production';
 
 const serverRoot = path.resolve(__dirname, '..', '..');
 const resolvedUploadDir = process.env.UPLOAD_DIR

--- a/server/src/config/runtimeChecks.ts
+++ b/server/src/config/runtimeChecks.ts
@@ -16,7 +16,6 @@ const sensitiveEnvVars: Array<{
   fallbackActive: () => boolean;
   fallbackMessage: string;
 }> = [
-codex/update-jwt-config-with-fallback-defaults
   {
     key: 'JWT_SECRET',
     description: 'JWT secret',
@@ -41,12 +40,6 @@ codex/update-jwt-config-with-fallback-defaults
     fallbackMessage:
       'ADMIN_PASSWORD is not set. Using the development fallback password intended only for local testing.',
   },
-=======
-  { key: 'DATABASE_URL', description: 'Database connection string', required: false },
-  { key: 'JWT_SECRET', description: 'JWT secret', required: true },
-  { key: 'ADMIN_USERNAME', description: 'Admin username', required: true },
-  { key: 'ADMIN_PASSWORD', description: 'Admin password', required: true },
-main
 ];
 
 export const performStartupChecks = (): StartupCheckResult[] => {


### PR DESCRIPTION
## Summary
- clean up the server environment configuration, restoring optional env loading and fallback tracking after a bad merge
- update runtime startup checks to reference the restored fallback helpers while keeping graceful shutdown handling intact

## Testing
- npm --prefix server run build

------
https://chatgpt.com/codex/tasks/task_e_68d657061230833285aaf5df31908679