### PR TITLE
fix: allow opting into production fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use **Vercel / Render / Railway / Codex Cloud Project Settings** to configure ac
 
 ### Secure configuration & rotation checklist
 
-The server refuses to start unless `JWT_SECRET`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` are provided. Follow the checklist below for
+By default the server refuses to start unless `JWT_SECRET`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` are provided. Follow the checklist below for
 every environment:
 
 1. **Generate strong values**
@@ -67,7 +67,11 @@ every environment:
 5. **Emergency rotation**: if compromise is suspected, immediately replace the values, redeploy, and review audit logs for
    suspicious activity.
 
-For the Vite frontend, copy `client/.env.example` to `client/.env` and set `VITE_API_BASE_URL` to your backend URL (defaults to `http://localhost:3000/api`).  
+For the Vite frontend, copy `client/.env.example` to `client/.env` and set `VITE_API_BASE_URL` to your backend URL (defaults to `http://localhost:3000/api`).
+
+### Temporarily allowing development fallbacks in production
+
+If you need to bring the API online before the production secrets are ready (for example, while validating a new hosting environment), set `ALLOW_DEVELOPMENT_FALLBACKS=true`. When this override is active, the API boots with the development defaults, admin login stays disabled, and startup checks emit warnings reminding you to finish the secure setup.
 
 ---
 

--- a/server/src/config/runtimeChecks.ts
+++ b/server/src/config/runtimeChecks.ts
@@ -90,6 +90,30 @@ export const performStartupChecks = (): StartupCheckResult[] => {
     message: `Running in "${env.nodeEnv}" mode.`,
   });
 
+  if (env.isStrictSecretEnforcementEnabled) {
+    results.push({
+      name: 'Secret enforcement mode',
+      status: 'passed',
+      message:
+        env.nodeEnv === 'production'
+          ? 'Production startup requires secure JWT and admin credentials.'
+          : 'Strict secret enforcement is enabled despite NODE_ENV not being "production".',
+    });
+  } else if (env.allowDevelopmentFallbacksInProduction) {
+    results.push({
+      name: 'Secret enforcement mode',
+      status: 'warning',
+      message:
+        'Development fallbacks are enabled while NODE_ENV is "production". Admin login remains disabled until secure credentials are configured.',
+    });
+  } else {
+    results.push({
+      name: 'Secret enforcement mode',
+      status: 'warning',
+      message: 'Development fallbacks are enabled because NODE_ENV is not "production".',
+    });
+  }
+
   {
     const databaseUrl = env.databaseUrl;
     if (typeof databaseUrl === 'string') {


### PR DESCRIPTION
## Summary
- allow the API to opt into development credential fallbacks in production through the ALLOW_DEVELOPMENT_FALLBACKS flag
- surface the new enforcement state in startup checks and cover it with integration tests
- document how to use the override while keeping admin access disabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6588a5bcc83328b89f0269a787b02