### PR TITLE
Add root endpoint handler and integration test

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,6 +15,13 @@ export const createApp = () => {
   app.use(morgan(env.nodeEnv === 'production' ? 'combined' : 'dev'));
   app.use('/uploads', express.static(env.uploadDir));
 
+  const rootHandler: express.RequestHandler = (_req, res) => {
+    res.json({ status: 'ok' });
+  };
+
+  app.get('/', rootHandler);
+  app.head('/', rootHandler);
+
   app.get('/api', (_req: express.Request, res: express.Response) => {
     const response = res as express.Response;
 

--- a/tests/products.test.ts
+++ b/tests/products.test.ts
@@ -14,6 +14,33 @@ const { default: env } = await import('../server/src/config/env');
 const { default: createApp } = await import('../server/src/app');
 const { default: productsStore } = await import('../server/src/store/productsStore');
 
+describe('root endpoint', () => {
+  let server: Server;
+
+  afterEach(async () => {
+    if (server) {
+      server.close();
+      await once(server, 'close');
+    }
+  });
+
+  it('responds with 200 status code', async () => {
+    const app = createApp();
+    server = app.listen(0);
+
+    await once(server, 'listening');
+
+    const address = server.address();
+    assert.ok(address && typeof address !== 'string', 'Expected address info');
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/`);
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.status, 'ok');
+  });
+});
+
 const runFallbackAuthCheck = async () => {
   const appModuleUrl = new URL('../server/src/app.ts', import.meta.url);
   const envModuleUrl = new URL('../server/src/config/env.ts', import.meta.url);


### PR DESCRIPTION
## Summary
- add a JSON-producing handler for the application root to satisfy health checks
- cover the root endpoint with an integration test that starts the app

## Testing
- npm run build (server/)
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d65d80dcc483328cdc81733d89a5ae