### PR TITLE
feat: add admin product management ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ README.md
 - [x] Customer: Browse products with images, name, price  
 - [x] Customer: Add/remove/update items in cart  
 - [x] Customer: Checkout flow (address + payment placeholder)  
-- [ ] Admin: Login/Logout with JWT  
-- [ ] Admin: Add/Edit/Delete products  
+- [ ] Admin: Login/Logout with JWT
+- [x] Admin: Add/Edit products (dashboard + API)
+- [ ] Admin: Delete products
 - [ ] Admin: Upload product images  
 - [ ] System: Store data in MongoDB Atlas  
 - [x] System: Responsive UI (mobile + desktop)  

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -142,7 +142,23 @@ a:hover {
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.form-field textarea {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  resize: vertical;
+  min-height: 140px;
+}
+
 .form-field input:focus-visible {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.form-field textarea:focus-visible {
   outline: none;
   border-color: #2563eb;
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
@@ -347,6 +363,122 @@ a:hover {
   background: rgba(248, 113, 113, 0.12);
   color: #b91c1c;
   border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.alert--success {
+  background: rgba(74, 222, 128, 0.18);
+  color: #166534;
+  border: 1px solid rgba(74, 222, 128, 0.4);
+}
+
+.admin-layout {
+  display: grid;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+@media (min-width: 960px) {
+  .admin-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.admin-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #0f172a;
+}
+
+.admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-form__row {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .admin-form__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.admin-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.admin-empty-state {
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: #334155;
+}
+
+.admin-product-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-product-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #f8fafc;
+}
+
+.admin-product-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.admin-product-item__name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.admin-product-item__price {
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.admin-product-item__stock {
+  color: #475569;
+}
+
+.admin-product-item__description {
+  margin: 0;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.admin-product-item__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .empty-state {

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1,23 +1,91 @@
-import { FormEvent, useState } from 'react';
-import { ApiError, login } from '../lib/api';
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
+import {
+  ApiError,
+  createProduct,
+  getProducts,
+  login,
+  updateProduct,
+  type Product,
+} from '../lib/api';
+
+type ProductFormState = {
+  name: string;
+  description: string;
+  price: string;
+  stock: string;
+  imageFile: File | null;
+};
+
+const emptyFormState: ProductFormState = {
+  name: '',
+  description: '',
+  price: '',
+  stock: '',
+  imageFile: null,
+};
 
 const AdminPage = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [token, setToken] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [isLoadingProducts, setIsLoadingProducts] = useState(false);
+  const [productsError, setProductsError] = useState<string | null>(null);
+  const [formState, setFormState] = useState<ProductFormState>(emptyFormState);
+  const [formMessage, setFormMessage] = useState<{ type: 'error' | 'success'; text: string } | null>(
+    null,
+  );
+  const [isSavingProduct, setIsSavingProduct] = useState(false);
+  const [editingProductId, setEditingProductId] = useState<string | null>(null);
+  const [fileInputKey, setFileInputKey] = useState(0);
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    let isCancelled = false;
+
+    const loadProducts = async () => {
+      setIsLoadingProducts(true);
+      setProductsError(null);
+
+      try {
+        const data = await getProducts();
+
+        if (!isCancelled) {
+          setProducts(data);
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          setProductsError('載入產品列表時發生錯誤，請稍後再試。');
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoadingProducts(false);
+        }
+      }
+    };
+
+    void loadProducts();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [token]);
+
+  const handleLoginSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (!username || !password) {
-      setError('請輸入帳號與密碼。');
+      setLoginError('請輸入帳號與密碼。');
       return;
     }
 
     setIsSubmitting(true);
-    setError(null);
+    setLoginError(null);
 
     try {
       const response = await login({ username, password });
@@ -25,56 +93,326 @@ const AdminPage = () => {
     } catch (err) {
       setToken(null);
 
-      if (err instanceof ApiError && err.status === 401) {
-        setError('登入失敗，請確認帳號或密碼。');
+      if (err instanceof ApiError) {
+        if (err.status === 401) {
+          setLoginError('登入失敗，請確認帳號或密碼。');
+        } else if (err.status === 503) {
+          setLoginError('尚未設定正式管理帳號，暫時無法登入。');
+        } else {
+          setLoginError('登入過程發生錯誤，請稍後再試。');
+        }
       } else {
-        setError('登入過程發生錯誤，請稍後再試。');
+        setLoginError('登入過程發生錯誤，請稍後再試。');
       }
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  if (token) {
+  const handleInputChange = <K extends keyof ProductFormState>(key: K, value: ProductFormState[K]) => {
+    setFormState((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+
+  const resetForm = () => {
+    setFormState(emptyFormState);
+    setEditingProductId(null);
+    setFileInputKey((prev) => prev + 1);
+  };
+
+  const handleEditProduct = (product: Product) => {
+    setEditingProductId(product.id);
+    setFormState({
+      name: product.name,
+      description: product.description ?? '',
+      price: product.price.toString(),
+      stock: product.stock !== undefined ? product.stock.toString() : '',
+      imageFile: null,
+    });
+    setFormMessage(null);
+    setFileInputKey((prev) => prev + 1);
+  };
+
+  const handleCancelEdit = () => {
+    resetForm();
+    setFormMessage(null);
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files && event.target.files[0] ? event.target.files[0] : null;
+    handleInputChange('imageFile', file);
+  };
+
+  const parsePriceAndStock = () => {
+    const trimmedName = formState.name.trim();
+
+    if (!trimmedName) {
+      setFormMessage({ type: 'error', text: '請輸入產品名稱。' });
+      return null;
+    }
+
+    const priceValue = Number(formState.price);
+
+    if (Number.isNaN(priceValue)) {
+      setFormMessage({ type: 'error', text: '請輸入有效的價格。' });
+      return null;
+    }
+
+    let stockValue: number | undefined;
+
+    if (formState.stock.trim() !== '') {
+      const parsedStock = Number(formState.stock);
+
+      if (Number.isNaN(parsedStock)) {
+        setFormMessage({ type: 'error', text: '請輸入有效的庫存數量。' });
+        return null;
+      }
+
+      stockValue = parsedStock;
+    }
+
+    return {
+      name: trimmedName,
+      price: priceValue,
+      stock: stockValue,
+      description: formState.description.trim() || undefined,
+      imageFile: formState.imageFile,
+    };
+  };
+
+  const handleProductSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!token) {
+      setFormMessage({ type: 'error', text: '請重新登入後再試。' });
+      return;
+    }
+
+    const parsed = parsePriceAndStock();
+
+    if (!parsed) {
+      return;
+    }
+
+    setIsSavingProduct(true);
+    setFormMessage(null);
+
+    try {
+      if (editingProductId) {
+        const updated = await updateProduct(editingProductId, parsed, token);
+        setProducts((prev) => prev.map((product) => (product.id === updated.id ? updated : product)));
+        setFormMessage({ type: 'success', text: '產品已更新。' });
+      } else {
+        const created = await createProduct(parsed, token);
+        setProducts((prev) => [created, ...prev]);
+        setFormMessage({ type: 'success', text: '產品已新增。' });
+      }
+
+      resetForm();
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.status === 400) {
+          setFormMessage({ type: 'error', text: '送出的資料有誤，請確認後再試。' });
+        } else if (error.status === 401) {
+          setFormMessage({ type: 'error', text: '登入逾時，請重新登入。' });
+          setToken(null);
+        } else if (error.status === 404) {
+          setFormMessage({ type: 'error', text: '找不到這項產品，請重新整理列表。' });
+        } else {
+          setFormMessage({ type: 'error', text: '儲存產品時發生錯誤，請稍後再試。' });
+        }
+      } else {
+        setFormMessage({ type: 'error', text: '儲存產品時發生錯誤，請稍後再試。' });
+      }
+    } finally {
+      setIsSavingProduct(false);
+    }
+  };
+
+  const handleLogout = () => {
+    setToken(null);
+    setProducts([]);
+    resetForm();
+    setLoginError(null);
+    setProductsError(null);
+    setFormMessage(null);
+  };
+
+  if (!token) {
     return (
       <section className="page">
-        <h1>管理後台</h1>
-        <p>新增/編輯/刪除產品</p>
+        <h1>管理員登入</h1>
+        <form className="form" onSubmit={handleLoginSubmit}>
+          <label className="form-field">
+            <span>帳號</span>
+            <input
+              type="text"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              autoComplete="username"
+              disabled={isSubmitting}
+              required
+            />
+          </label>
+          <label className="form-field">
+            <span>密碼</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete="current-password"
+              disabled={isSubmitting}
+              required
+            />
+          </label>
+          {loginError ? <p className="form-error">{loginError}</p> : null}
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '登入中…' : '登入'}
+          </button>
+        </form>
       </section>
     );
   }
 
   return (
     <section className="page">
-      <h1>管理員登入</h1>
-      <form className="form" onSubmit={handleSubmit}>
-        <label className="form-field">
-          <span>帳號</span>
-          <input
-            type="text"
-            value={username}
-            onChange={(event) => setUsername(event.target.value)}
-            autoComplete="username"
-            disabled={isSubmitting}
-            required
-          />
-        </label>
-        <label className="form-field">
-          <span>密碼</span>
-          <input
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            autoComplete="current-password"
-            disabled={isSubmitting}
-            required
-          />
-        </label>
-        {error ? <p className="form-error">{error}</p> : null}
-        <button type="submit" disabled={isSubmitting}>
-          {isSubmitting ? '登入中…' : '登入'}
-        </button>
-      </form>
+      <header className="page__header">
+        <div>
+          <h1 className="page__title">產品管理後台</h1>
+          <p className="page__subtitle">新增或編輯商品資訊，維護最新的商品清單。</p>
+        </div>
+        <div className="page__actions">
+          <button type="button" className="button button--ghost" onClick={handleLogout}>
+            登出
+          </button>
+        </div>
+      </header>
+
+      <div className="admin-layout">
+        <section className="admin-card">
+          <h2 className="admin-card__title">{editingProductId ? '編輯產品' : '新增產品'}</h2>
+          <form className="admin-form" onSubmit={handleProductSubmit}>
+            <label className="form-field">
+              <span>產品名稱</span>
+              <input
+                type="text"
+                value={formState.name}
+                onChange={(event) => handleInputChange('name', event.target.value)}
+                required
+                disabled={isSavingProduct}
+              />
+            </label>
+            <label className="form-field">
+              <span>產品描述</span>
+              <textarea
+                value={formState.description}
+                onChange={(event) => handleInputChange('description', event.target.value)}
+                disabled={isSavingProduct}
+                rows={4}
+              />
+            </label>
+            <div className="admin-form__row">
+              <label className="form-field">
+                <span>價格 (NT$)</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={formState.price}
+                  onChange={(event) => handleInputChange('price', event.target.value)}
+                  required
+                  disabled={isSavingProduct}
+                />
+              </label>
+              <label className="form-field">
+                <span>庫存數量</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={formState.stock}
+                  onChange={(event) => handleInputChange('stock', event.target.value)}
+                  disabled={isSavingProduct}
+                />
+              </label>
+            </div>
+            <label className="form-field">
+              <span>商品圖片</span>
+              <input
+                key={fileInputKey}
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                disabled={isSavingProduct}
+              />
+            </label>
+            {formMessage ? (
+              <p
+                className={`alert ${
+                  formMessage.type === 'error' ? 'alert--error' : 'alert--success'
+                }`}
+              >
+                {formMessage.text}
+              </p>
+            ) : null}
+            <div className="admin-form__actions">
+              {editingProductId ? (
+                <button
+                  type="button"
+                  className="button button--secondary"
+                  onClick={handleCancelEdit}
+                  disabled={isSavingProduct}
+                >
+                  取消編輯
+                </button>
+              ) : null}
+              <button type="submit" className="button button--primary" disabled={isSavingProduct}>
+                {isSavingProduct ? '儲存中…' : editingProductId ? '更新產品' : '新增產品'}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section className="admin-card">
+          <h2 className="admin-card__title">現有產品</h2>
+          {productsError ? <p className="alert alert--error">{productsError}</p> : null}
+          {isLoadingProducts ? <p>載入中…</p> : null}
+          {!isLoadingProducts && products.length === 0 && !productsError ? (
+            <div className="admin-empty-state">
+              <p>目前尚未新增任何產品。</p>
+              <p>建立第一個產品後即可在此處看到清單。</p>
+            </div>
+          ) : null}
+          <ul className="admin-product-list">
+            {products.map((product) => (
+              <li key={product.id} className="admin-product-item">
+                <div className="admin-product-item__info">
+                  <span className="admin-product-item__name">{product.name}</span>
+                  <span className="admin-product-item__price">NT$ {product.price.toLocaleString()}</span>
+                  {product.stock !== undefined ? (
+                    <span className="admin-product-item__stock">庫存：{product.stock}</span>
+                  ) : null}
+                  {product.description ? (
+                    <p className="admin-product-item__description">{product.description}</p>
+                  ) : null}
+                </div>
+                <div className="admin-product-item__actions">
+                  <button
+                    type="button"
+                    className="button button--ghost"
+                    onClick={() => handleEditProduct(product)}
+                    disabled={isSavingProduct}
+                  >
+                    編輯
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- build an admin dashboard that loads products after login and provides forms to create or edit catalog entries
- extend the client API to support multipart product requests and add styles for the management layout
- update the README feature checklist to reflect the new admin capabilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d76e3557408332ad010385d58301e3