### PR TITLE
Persist admin auth token across refreshes

### DIFF
--- a/client/src/lib/cookies.ts
+++ b/client/src/lib/cookies.ts
@@ -1,0 +1,77 @@
+const isBrowser = typeof document !== 'undefined';
+
+const escapeCookieName = (name: string) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const getCookie = (name: string): string | null => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const pattern = new RegExp(`(?:^|; )${escapeCookieName(name)}=([^;]*)`);
+  const match = document.cookie.match(pattern);
+
+  if (!match) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+};
+
+type SameSiteOption = 'Strict' | 'Lax' | 'None' | 'strict' | 'lax' | 'none';
+
+interface CookieOptions {
+  maxAgeSeconds?: number;
+  path?: string;
+  secure?: boolean;
+  sameSite?: SameSiteOption;
+}
+
+export const setCookie = (name: string, value: string, options?: CookieOptions) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  const parts = [`${name}=${encodeURIComponent(value)}`];
+  const path = options?.path ?? '/';
+  parts.push(`Path=${path}`);
+
+  if (typeof options?.maxAgeSeconds === 'number') {
+    parts.push(`Max-Age=${Math.max(0, Math.floor(options.maxAgeSeconds))}`);
+  }
+
+  if (options?.secure) {
+    parts.push('Secure');
+  }
+
+  if (options?.sameSite) {
+    const sameSiteValue = options.sameSite;
+    const normalizedSameSite =
+      typeof sameSiteValue === 'string' && sameSiteValue.length > 0
+        ? `${sameSiteValue[0].toUpperCase()}${sameSiteValue.slice(1).toLowerCase()}`
+        : undefined;
+
+    if (normalizedSameSite) {
+      parts.push(`SameSite=${normalizedSameSite}`);
+    }
+  }
+
+  document.cookie = parts.join('; ');
+};
+
+export const deleteCookie = (name: string, path = '/') => {
+  if (!isBrowser) {
+    return;
+  }
+
+  document.cookie = `${name}=; Path=${path}; Max-Age=0`;
+};
+
+export default {
+  getCookie,
+  setCookie,
+  deleteCookie,
+};

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -7,6 +7,7 @@ import {
   updateProduct,
   type Product,
 } from '../lib/api';
+import { deleteCookie, getCookie, setCookie } from '../lib/cookies';
 
 type ProductFormState = {
   name: string;
@@ -24,11 +25,14 @@ const emptyFormState: ProductFormState = {
   imageFile: null,
 };
 
+const TOKEN_COOKIE_NAME = 'admin_token';
+const TOKEN_COOKIE_MAX_AGE_SECONDS = 60 * 60;
+
 const AdminPage = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [token, setToken] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(() => getCookie(TOKEN_COOKIE_NAME));
   const [loginError, setLoginError] = useState<string | null>(null);
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoadingProducts, setIsLoadingProducts] = useState(false);
@@ -40,6 +44,18 @@ const AdminPage = () => {
   const [isSavingProduct, setIsSavingProduct] = useState(false);
   const [editingProductId, setEditingProductId] = useState<string | null>(null);
   const [fileInputKey, setFileInputKey] = useState(0);
+
+  useEffect(() => {
+    if (token) {
+      setCookie(TOKEN_COOKIE_NAME, token, {
+        maxAgeSeconds: TOKEN_COOKIE_MAX_AGE_SECONDS,
+        sameSite: 'strict',
+        path: '/',
+      });
+    } else {
+      deleteCookie(TOKEN_COOKIE_NAME);
+    }
+  }, [token]);
 
   useEffect(() => {
     if (!token) {
@@ -233,6 +249,7 @@ const AdminPage = () => {
 
   const handleLogout = () => {
     setToken(null);
+    deleteCookie(TOKEN_COOKIE_NAME);
     setProducts([]);
     resetForm();
     setLoginError(null);


### PR DESCRIPTION
## Summary
- add a cookie helper to manage reading, writing, and clearing browser cookies
- persist the admin JWT in a cookie so the dashboard stays logged in after refresh and clear it on logout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d779de75f08332b546ecb3e64c88d1