### PR TITLE
Add hero settings management and homepage hero section

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -399,6 +399,103 @@ a:hover {
   color: #0f172a;
 }
 
+.admin-hero-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hero-preview {
+  position: relative;
+  border-radius: 1rem;
+  overflow: hidden;
+  min-height: 220px;
+  background: linear-gradient(135deg, #1e3a8a, #9333ea);
+  color: #f8fafc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+}
+
+.hero-preview--with-image {
+  background-size: cover;
+  background-position: center;
+}
+
+.hero-preview__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.hero-preview--with-image .hero-preview__backdrop {
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.hero-preview__content {
+  position: relative;
+  z-index: 1;
+  max-width: 520px;
+}
+
+.hero-preview__copy {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.7;
+  white-space: pre-wrap;
+}
+
+.hero-preview__hint {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.home-hero {
+  position: relative;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: linear-gradient(135deg, #1d4ed8, #7c3aed);
+  color: #f8fafc;
+  padding: clamp(3rem, 6vw, 5rem) clamp(1.5rem, 5vw, 3.5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+}
+
+.home-hero--with-image {
+  background-size: cover;
+  background-position: center;
+}
+
+.home-hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.home-hero--with-image .home-hero__overlay {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.home-hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  text-align: center;
+}
+
+.home-hero__copy {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.75rem);
+  line-height: 1.5;
+  font-weight: 600;
+  white-space: pre-wrap;
+}
+
 .admin-form {
   display: flex;
   flex-direction: column;

--- a/client/src/pages/HomeProductsPage.tsx
+++ b/client/src/pages/HomeProductsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import ProductCard from '../components/ProductCard';
 import { useCart } from '../context/CartContext';
-import { getProducts, type Product } from '../lib/api';
+import { getHeroSettings, getProducts, type HeroSettings, type Product } from '../lib/api';
 
 const ITEMS_PER_BATCH = 8;
 
@@ -11,6 +11,31 @@ const HomeProductsPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [visibleCount, setVisibleCount] = useState(ITEMS_PER_BATCH);
+  const [heroSettings, setHeroSettings] = useState<HeroSettings | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchHero = async () => {
+      try {
+        const data = await getHeroSettings();
+
+        if (!cancelled) {
+          setHeroSettings(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setHeroSettings(null);
+        }
+      }
+    };
+
+    void fetchHero();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -75,8 +100,22 @@ const HomeProductsPage = () => {
     [],
   );
 
+  const heroCopy = heroSettings?.copy?.trim()
+    ? heroSettings.copy
+    : 'Discover products curated to brighten your day and elevate your routine.';
+  const heroHasImage = Boolean(heroSettings?.backgroundImageUrl);
+
   return (
     <section className="page">
+      <div
+        className={`home-hero${heroHasImage ? ' home-hero--with-image' : ''}`}
+        style={heroHasImage ? { backgroundImage: `url(${heroSettings?.backgroundImageUrl})` } : undefined}
+      >
+        <div className="home-hero__overlay" aria-hidden="true" />
+        <div className="home-hero__content">
+          <p className="home-hero__copy">{heroCopy}</p>
+        </div>
+      </div>
       <header className="page__header">
         <h1 className="page__title">Products</h1>
         <p className="page__subtitle">Browse our curated catalog and discover your next purchase.</p>

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import morgan from 'morgan';
 import env from './config/env.js';
 import healthRouter from './routes/health.js';
 import productsRouter from './routes/products.js';
+import heroRouter from './routes/hero.js';
 import authRouter from './routes/auth.js';
 
 export const createApp = () => {
@@ -35,6 +36,7 @@ export const createApp = () => {
   app.use('/api/auth', authRouter);
   app.use('/api/health', healthRouter);
   app.use('/api/products', productsRouter);
+  app.use('/api/hero', heroRouter);
 
   return app;
 };

--- a/server/src/models/heroSettings.ts
+++ b/server/src/models/heroSettings.ts
@@ -1,0 +1,11 @@
+export interface HeroSettings {
+  copy: string;
+  backgroundImageUrl?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type UpdateHeroSettingsInput = {
+  copy?: string;
+  backgroundImageUrl?: string | null;
+};

--- a/server/src/routes/hero.ts
+++ b/server/src/routes/hero.ts
@@ -1,0 +1,139 @@
+// @ts-nocheck
+import fs from 'node:fs';
+import path from 'node:path';
+import express from 'express';
+import multer from 'multer';
+import type { MulterFile } from 'multer';
+import env from '../config/env.js';
+import heroSettingsStore from '../store/heroSettingsStore.js';
+import { requireAdmin } from '../middleware/auth.js';
+
+const router = express.Router();
+
+fs.mkdirSync(env.uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (
+    _req: express.Request,
+    _file: MulterFile,
+    cb: (error: Error | null, destination: string) => void,
+  ) => {
+    cb(null, env.uploadDir);
+  },
+  filename: (
+    _req: express.Request,
+    file: MulterFile,
+    cb: (error: Error | null, filename: string) => void,
+  ) => {
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    const extension = path.extname(file.originalname);
+    cb(null, `${uniqueSuffix}${extension}`);
+  },
+});
+
+const upload = multer({ storage });
+
+const buildImageUrl = (filename: string) => `/uploads/${filename}`;
+
+const removeImageFile = async (imageUrl?: string) => {
+  if (!imageUrl) {
+    return;
+  }
+
+  const filename = path.basename(imageUrl);
+  const filePath = path.join(env.uploadDir, filename);
+
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};
+
+const removeUploadedFile = async (file?: MulterFile | null) => {
+  if (!file) {
+    return;
+  }
+
+  let filePath = file.path;
+
+  if (!filePath) {
+    const { filename } = file;
+    const destination = file.destination ?? env.uploadDir;
+
+    if (!filename || !destination) {
+      return;
+    }
+
+    filePath = path.join(destination, filename);
+  }
+
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};
+
+router.get('/', (_req: express.Request, res: express.Response) => {
+  const response = res as express.Response;
+  const settings = heroSettingsStore.get();
+  response.json(settings);
+});
+
+router.put('/', requireAdmin, upload.single('image'), async (req: express.Request, res: express.Response) => {
+  const request = req as express.Request & {
+    body: Record<string, unknown>;
+    file?: MulterFile;
+  };
+  const response = res as express.Response;
+  const body = (request.body ?? {}) as Record<string, unknown>;
+  const copy = body.copy as string | undefined;
+  const removeImageFlag = body.removeImage;
+  const removeImage = removeImageFlag === 'true' || removeImageFlag === true || removeImageFlag === '1';
+
+  const existing = heroSettingsStore.get();
+
+  if (request.file) {
+    const newImageUrl = buildImageUrl(request.file.filename);
+
+    if (existing.backgroundImageUrl) {
+      try {
+        await removeImageFile(existing.backgroundImageUrl);
+      } catch (error) {
+        await removeUploadedFile(request.file);
+        return response.status(500).json({ message: 'Failed to update hero image' });
+      }
+    }
+
+    const updated = heroSettingsStore.update({
+      copy,
+      backgroundImageUrl: newImageUrl,
+    });
+
+    return response.json(updated);
+  }
+
+  if (removeImage && existing.backgroundImageUrl) {
+    try {
+      await removeImageFile(existing.backgroundImageUrl);
+    } catch (error) {
+      return response.status(500).json({ message: 'Failed to remove hero image' });
+    }
+  }
+
+  const updated = heroSettingsStore.update({
+    copy,
+    backgroundImageUrl: removeImage ? null : undefined,
+  });
+
+  return response.json(updated);
+});
+
+export default router;

--- a/server/src/store/heroSettingsStore.ts
+++ b/server/src/store/heroSettingsStore.ts
@@ -1,0 +1,41 @@
+import { HeroSettings, UpdateHeroSettingsInput } from '../models/heroSettings.js';
+
+const defaultCopy = 'Discover the latest arrivals and exclusive deals tailored for you.';
+
+class HeroSettingsStore {
+  private settings: HeroSettings;
+
+  constructor() {
+    const now = new Date();
+    this.settings = {
+      copy: defaultCopy,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  get() {
+    return this.settings;
+  }
+
+  update(input: UpdateHeroSettingsInput) {
+    const now = new Date();
+
+    this.settings = {
+      ...this.settings,
+      copy: input.copy !== undefined ? input.copy : this.settings.copy,
+      backgroundImageUrl:
+        input.backgroundImageUrl === null
+          ? undefined
+          : input.backgroundImageUrl ?? this.settings.backgroundImageUrl,
+      updatedAt: now,
+    };
+
+    return this.settings;
+  }
+}
+
+const heroSettingsStore = new HeroSettingsStore();
+
+export default heroSettingsStore;
+export { HeroSettingsStore };


### PR DESCRIPTION
## Summary
- add a dedicated hero settings model/store and API route with upload support
- extend the client API along with admin UI controls for managing the hero content
- render the configurable hero section on the storefront with updated styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db92723be4833284e41f4bfc8d76f7