### PR TITLE
Update hero banner layout to highlight background image

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -455,7 +455,6 @@ a:hover {
 
 .home-hero {
   position: relative;
-  border-radius: 1.5rem;
   overflow: hidden;
   background: linear-gradient(135deg, #1d4ed8, #7c3aed);
   color: #f8fafc;
@@ -464,11 +463,16 @@ a:hover {
   align-items: center;
   justify-content: center;
   margin-bottom: 0.5rem;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  width: 100vw;
+  max-width: none;
 }
 
 .home-hero--with-image {
   background-size: cover;
   background-position: center;
+  background-repeat: no-repeat;
 }
 
 .home-hero__overlay {
@@ -478,7 +482,7 @@ a:hover {
 }
 
 .home-hero--with-image .home-hero__overlay {
-  background: rgba(15, 23, 42, 0.6);
+  background: transparent;
 }
 
 .home-hero__content {

--- a/client/src/pages/HomeProductsPage.tsx
+++ b/client/src/pages/HomeProductsPage.tsx
@@ -111,7 +111,7 @@ const HomeProductsPage = () => {
         className={`home-hero${heroHasImage ? ' home-hero--with-image' : ''}`}
         style={heroHasImage ? { backgroundImage: `url(${heroSettings?.backgroundImageUrl})` } : undefined}
       >
-        <div className="home-hero__overlay" aria-hidden="true" />
+        {!heroHasImage && <div className="home-hero__overlay" aria-hidden="true" />}
         <div className="home-hero__content">
           <p className="home-hero__copy">{heroCopy}</p>
         </div>


### PR DESCRIPTION
## Summary
- remove the hero banner's rounded corners and image overlay so uploaded photos keep their original colors
- allow the hero section to span the full viewport width while preserving cover positioning for background images

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9af184d08332ab3d1707b9ce3b73