### PR TITLE
feat: size home hero by background image aspect ratio

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -465,11 +465,6 @@ a:hover {
   overflow: hidden;
   background: linear-gradient(135deg, #1d4ed8, #7c3aed);
   color: #f8fafc;
-codex/increase-hero-image-height-by-50%-22ybqv
-  padding: clamp(9rem, 18vw, 15rem) clamp(1.5rem, 5vw, 3.5rem);
-=======
-  padding: clamp(6.75rem, 13.5vw, 11.25rem) clamp(1.5rem, 5vw, 3.5rem);
- main
   display: flex;
   align-items: center;
   justify-content: center;
@@ -480,10 +475,15 @@ codex/increase-hero-image-height-by-50%-22ybqv
   max-width: none;
 }
 
+.home-hero:not(.home-hero--with-image) {
+  padding: clamp(6.75rem, 13.5vw, 11.25rem) clamp(1.5rem, 5vw, 3.5rem);
+}
+
 .home-hero--with-image {
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+  padding: 0;
 }
 
 .home-hero__overlay {
@@ -501,6 +501,25 @@ codex/increase-hero-image-height-by-50%-22ybqv
   z-index: 1;
   max-width: 720px;
   text-align: center;
+  margin: 0 auto;
+}
+
+.home-hero--with-image .home-hero__content {
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  padding: clamp(6.75rem, 13.5vw, 11.25rem) clamp(1.5rem, 5vw, 3.5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.65), rgba(15, 23, 42, 0.35));
+  backdrop-filter: blur(2px);
+}
+
+.home-hero--with-image .home-hero__copy {
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .home-hero__copy {


### PR DESCRIPTION
## Summary
- compute the background image aspect ratio on the home page and apply it to the hero container
- refine the hero styles so gradient-only and image-backed variants keep appropriate spacing and readability

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dbddcb23e88332828c6244367bdb70